### PR TITLE
Fix `requirements.txt` version ranges ranges

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -r tools/splat/requirements.txt
-mapfile-parser>=1.1.2<2.0.0
+mapfile-parser>=1.1.2,<2.0.0


### PR DESCRIPTION
The version specifiers should be separated by commas.  More info: [PEP 440](https://peps.python.org/pep-0440/#version-specifiers)