### PR TITLE
Add missing headers to actors

### DIFF
--- a/src/overlays/actors/ovl_Airplane/ac_airplane.c
+++ b/src/overlays/actors/ovl_Airplane/ac_airplane.c
@@ -1,4 +1,6 @@
 #include "ac_airplane.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Airplane_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Animal_Logo/ac_animal_logo.c
+++ b/src/overlays/actors/ovl_Animal_Logo/ac_animal_logo.c
@@ -1,4 +1,6 @@
 #include "ac_animal_logo.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aAL_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Arrange_Furniture/ac_arrange_ftr.c
+++ b/src/overlays/actors/ovl_Arrange_Furniture/ac_arrange_ftr.c
@@ -1,4 +1,6 @@
 #include "ac_arrange_ftr.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Arrange_Furniture_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Arrange_Room/ac_arrange_room.c
+++ b/src/overlays/actors/ovl_Arrange_Room/ac_arrange_room.c
@@ -1,4 +1,6 @@
 #include "ac_arrange_room.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Arrange_Room_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ball/ac_ball.c
+++ b/src/overlays/actors/ovl_Ball/ac_ball.c
@@ -1,4 +1,6 @@
 #include "ac_ball.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aBALL_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Bee/ac_bee.c
+++ b/src/overlays/actors/ovl_Bee/ac_bee.c
@@ -1,4 +1,6 @@
 #include "ac_bee.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aBEE_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgCherryItem/bg_cherry_item.c
+++ b/src/overlays/actors/ovl_BgCherryItem/bg_cherry_item.c
@@ -1,4 +1,6 @@
 #include "bg_cherry_item.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bCI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgItem/bg_item.c
+++ b/src/overlays/actors/ovl_BgItem/bg_item.c
@@ -1,4 +1,6 @@
 #include "bg_item.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bIT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgPoliceItem/bg_police_item.c
+++ b/src/overlays/actors/ovl_BgPoliceItem/bg_police_item.c
@@ -1,5 +1,7 @@
 #include "bg_police_item.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bPI_actor_move(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgPostItem/bg_post_item.c
+++ b/src/overlays/actors/ovl_BgPostItem/bg_post_item.c
@@ -1,5 +1,7 @@
 #include "bg_post_item.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bPTI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgWinterItem/bg_winter_item.c
+++ b/src/overlays/actors/ovl_BgWinterItem/bg_winter_item.c
@@ -1,4 +1,6 @@
 #include "bg_winter_item.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bWI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BgXmasItem/bg_xmas_item.c
+++ b/src/overlays/actors/ovl_BgXmasItem/bg_xmas_item.c
@@ -1,4 +1,6 @@
 #include "bg_xmas_item.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void bXI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Birth_Control/ac_birth_control.c
+++ b/src/overlays/actors/ovl_Birth_Control/ac_birth_control.c
@@ -1,5 +1,7 @@
 #include "ac_birth_control.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aBC_actor_move(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BoxManager/ac_boxManager.c
+++ b/src/overlays/actors/ovl_BoxManager/ac_boxManager.c
@@ -1,4 +1,6 @@
 #include "ac_boxManager.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void BoxManager_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BoxMove/ac_boxMove.c
+++ b/src/overlays/actors/ovl_BoxMove/ac_boxMove.c
@@ -1,4 +1,6 @@
 #include "ac_boxMove.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void BoxMove_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BoxTrick01/ac_boxTrick01.c
+++ b/src/overlays/actors/ovl_BoxTrick01/ac_boxTrick01.c
@@ -1,5 +1,7 @@
 #include "ac_boxTrick01.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void BoxTrick01_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_BrShop/ac_br_shop.c
+++ b/src/overlays/actors/ovl_BrShop/ac_br_shop.c
@@ -1,4 +1,6 @@
 #include "ac_br_shop.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aBRS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Broker_Design/ac_broker_design.c
+++ b/src/overlays/actors/ovl_Broker_Design/ac_broker_design.c
@@ -1,4 +1,6 @@
 #include "ac_broker_design.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Broker_Design_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Buggy/ac_buggy.c
+++ b/src/overlays/actors/ovl_Buggy/ac_buggy.c
@@ -1,4 +1,6 @@
 #include "ac_buggy.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aBGY_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Conveni/ac_conveni.c
+++ b/src/overlays/actors/ovl_Conveni/ac_conveni.c
@@ -1,4 +1,6 @@
 #include "ac_conveni.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aCNV_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Count/ac_countdown.c
+++ b/src/overlays/actors/ovl_Count/ac_countdown.c
@@ -1,4 +1,6 @@
 #include "ac_countdown.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805ac0ac(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Count02/ac_count02.c
+++ b/src/overlays/actors/ovl_Count02/ac_count02.c
@@ -1,4 +1,6 @@
 #include "ac_count02.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805ab8b8(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Countdown_Npc0/ac_countdown_npc0.c
+++ b/src/overlays/actors/ovl_Countdown_Npc0/ac_countdown_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_countdown_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aCD0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Countdown_Npc1/ac_countdown_npc1.c
+++ b/src/overlays/actors/ovl_Countdown_Npc1/ac_countdown_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_countdown_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aCD1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Depart/ac_depart.c
+++ b/src/overlays/actors/ovl_Depart/ac_depart.c
@@ -1,4 +1,6 @@
 #include "ac_depart.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aDPT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Douzou/ac_douzou.c
+++ b/src/overlays/actors/ovl_Douzou/ac_douzou.c
@@ -1,4 +1,6 @@
 #include "ac_douzou.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aDOU_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Dummy/ac_dumm.c
+++ b/src/overlays/actors/ovl_Dummy/ac_dumm.c
@@ -1,4 +1,6 @@
 #include "ac_dumm.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Dummy_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Dump/ac_dump.c
+++ b/src/overlays/actors/ovl_Dump/ac_dump.c
@@ -1,4 +1,6 @@
 #include "ac_dump.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aDUM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Effect_Control/ef_effect_control.c
+++ b/src/overlays/actors/ovl_Effect_Control/ef_effect_control.c
@@ -1,4 +1,6 @@
 #include "ef_effect_control.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void eEC_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Effectbg/ac_effectbg.c
+++ b/src/overlays/actors/ovl_Effectbg/ac_effectbg.c
@@ -1,4 +1,6 @@
 #include "ac_effectbg.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Effectbg_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Angler/ac_ev_angler.c
+++ b/src/overlays/actors/ovl_Ev_Angler/ac_ev_angler.c
@@ -1,5 +1,7 @@
 #include "ac_ev_angler.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEANG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Artist/ac_ev_artist.c
+++ b/src/overlays/actors/ovl_Ev_Artist/ac_ev_artist.c
@@ -1,5 +1,7 @@
 #include "ac_ev_artist.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEART_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Broker/ac_ev_broker.c
+++ b/src/overlays/actors/ovl_Ev_Broker/ac_ev_broker.c
@@ -1,5 +1,7 @@
 #include "ac_ev_broker.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEBRK_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Broker2/ac_ev_broker2.c
+++ b/src/overlays/actors/ovl_Ev_Broker2/ac_ev_broker2.c
@@ -1,5 +1,7 @@
 #include "ac_ev_broker2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEBR2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_CarpetPeddler/ac_ev_carpetPeddler.c
+++ b/src/overlays/actors/ovl_Ev_CarpetPeddler/ac_ev_carpetPeddler.c
@@ -1,5 +1,7 @@
 #include "ac_ev_carpetPeddler.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aECPD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Cherry_Manager/ev_cherry_manager.c
+++ b/src/overlays/actors/ovl_Ev_Cherry_Manager/ev_cherry_manager.c
@@ -1,4 +1,6 @@
 #include "ev_cherry_manager.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void eChryMgr_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Designer/ac_ev_designer.c
+++ b/src/overlays/actors/ovl_Ev_Designer/ac_ev_designer.c
@@ -1,5 +1,7 @@
 #include "ac_ev_designer.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEDSN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Dokutu/ac_ev_dokutu.c
+++ b/src/overlays/actors/ovl_Ev_Dokutu/ac_ev_dokutu.c
@@ -1,5 +1,7 @@
 #include "ac_ev_dokutu.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEVD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Dozaemon/ac_ev_dozaemon.c
+++ b/src/overlays/actors/ovl_Ev_Dozaemon/ac_ev_dozaemon.c
@@ -1,5 +1,7 @@
 #include "ac_ev_dozaemon.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEDZ_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Gypsy/ac_ev_gypsy.c
+++ b/src/overlays/actors/ovl_Ev_Gypsy/ac_ev_gypsy.c
@@ -1,5 +1,7 @@
 #include "ac_ev_gypsy.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEGPS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_KabuPeddler/ac_ev_kabuPeddler.c
+++ b/src/overlays/actors/ovl_Ev_KabuPeddler/ac_ev_kabuPeddler.c
@@ -1,5 +1,7 @@
 #include "ac_ev_kabuPeddler.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEKPD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Miko/ac_ev_miko.c
+++ b/src/overlays/actors/ovl_Ev_Miko/ac_ev_miko.c
@@ -1,5 +1,7 @@
 #include "ac_ev_miko.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEMK_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Pumpkin/ac_ev_pumpkin.c
+++ b/src/overlays/actors/ovl_Ev_Pumpkin/ac_ev_pumpkin.c
@@ -1,5 +1,7 @@
 #include "ac_ev_pumpkin.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEPK_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Santa/ac_ev_santa.c
+++ b/src/overlays/actors/ovl_Ev_Santa/ac_ev_santa.c
@@ -1,5 +1,7 @@
 #include "ac_ev_santa.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aESNT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ev_Yomise/ac_ev_yomise.c
+++ b/src/overlays/actors/ovl_Ev_Yomise/ac_ev_yomise.c
@@ -1,5 +1,7 @@
 #include "ac_ev_yomise.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEYMS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Event_Manager/ac_event_manager.c
+++ b/src/overlays/actors/ovl_Event_Manager/ac_event_manager.c
@@ -1,4 +1,6 @@
 #include "ac_event_manager.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aEvMgr_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_FallS/ac_fallS.c
+++ b/src/overlays/actors/ovl_FallS/ac_fallS.c
@@ -1,4 +1,6 @@
 #include "ac_fallS.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80A03230_jp(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_FallSESW/ac_fallSESW.c
+++ b/src/overlays/actors/ovl_FallSESW/ac_fallSESW.c
@@ -1,4 +1,6 @@
 #include "ac_fallSESW.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80A034A0_jp(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Field_Draw/ac_field_draw.c
+++ b/src/overlays/actors/ovl_Field_Draw/ac_field_draw.c
@@ -1,4 +1,6 @@
 #include "ac_field_draw.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Bg_Draw_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Fieldm_Draw/ac_fieldm_draw.c
+++ b/src/overlays/actors/ovl_Fieldm_Draw/ac_fieldm_draw.c
@@ -1,4 +1,6 @@
 #include "ac_fieldm_draw.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Fieldm_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Fuusen/ac_fuusen.c
+++ b/src/overlays/actors/ovl_Fuusen/ac_fuusen.c
@@ -1,4 +1,6 @@
 #include "ac_fuusen.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aFSN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Garagara/ac_garagara.c
+++ b/src/overlays/actors/ovl_Garagara/ac_garagara.c
@@ -1,4 +1,6 @@
 #include "ac_garagara.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Garagara_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Goza/ac_goza.c
+++ b/src/overlays/actors/ovl_Goza/ac_goza.c
@@ -1,4 +1,6 @@
 #include "ac_goza.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aGOZ_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Gyo_Kage/ac_gyo_kage.c
+++ b/src/overlays/actors/ovl_Gyo_Kage/ac_gyo_kage.c
@@ -1,4 +1,6 @@
 #include "ac_gyo_kage.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aGYO_KAGE_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Gyo_Release/ac_gyo_release.c
+++ b/src/overlays/actors/ovl_Gyo_Release/ac_gyo_release.c
@@ -1,4 +1,6 @@
 #include "ac_gyo_release.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aGYR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Gyoei/ac_gyoei.c
+++ b/src/overlays/actors/ovl_Gyoei/ac_gyoei.c
@@ -1,4 +1,6 @@
 #include "ac_gyoei.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aGYO_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Halloween_Npc/ac_halloween_npc.c
+++ b/src/overlays/actors/ovl_Halloween_Npc/ac_halloween_npc.c
@@ -1,5 +1,7 @@
 #include "ac_halloween_npc.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHWN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hanabi_Npc0/ac_hanabi_npc0.c
+++ b/src/overlays/actors/ovl_Hanabi_Npc0/ac_hanabi_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_hanabi_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80528514(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hanabi_Npc1/ac_hanabi_npc1.c
+++ b/src/overlays/actors/ovl_Hanabi_Npc1/ac_hanabi_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_hanabi_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHN1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hanami_Npc0/ac_hanami_npc0.c
+++ b/src/overlays/actors/ovl_Hanami_Npc0/ac_hanami_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_hanami_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHM0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hanami_Npc1/ac_hanami_npc1.c
+++ b/src/overlays/actors/ovl_Hanami_Npc1/ac_hanami_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_hanami_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHM1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_HandOverItem/ac_handOverItem.c
+++ b/src/overlays/actors/ovl_HandOverItem/ac_handOverItem.c
@@ -1,4 +1,6 @@
 #include "ac_handOverItem.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHOI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Haniwa/ac_haniwa.c
+++ b/src/overlays/actors/ovl_Haniwa/ac_haniwa.c
@@ -1,5 +1,7 @@
 #include "ac_haniwa.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHNW_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hatumode_Control/ac_hatumode_control.c
+++ b/src/overlays/actors/ovl_Hatumode_Control/ac_hatumode_control.c
@@ -1,5 +1,7 @@
 #include "ac_hatumode_control.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHTC_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Hatumode_Npc0/ac_hatumode_npc0.c
+++ b/src/overlays/actors/ovl_Hatumode_Npc0/ac_hatumode_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_hatumode_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_8052ab54(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_House/ac_house.c
+++ b/src/overlays/actors/ovl_House/ac_house.c
@@ -1,4 +1,6 @@
 #include "ac_house.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHUS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_House_Clock/ac_house_clock.c
+++ b/src/overlays/actors/ovl_House_Clock/ac_house_clock.c
@@ -1,4 +1,6 @@
 #include "ac_house_clock.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void House_Clock_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_House_Goki/ac_house_goki.c
+++ b/src/overlays/actors/ovl_House_Goki/ac_house_goki.c
@@ -1,4 +1,6 @@
 #include "ac_house_goki.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aHG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Insect/ac_insect.c
+++ b/src/overlays/actors/ovl_Insect/ac_insect.c
@@ -1,4 +1,6 @@
 #include "ac_insect.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aINS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Intro_Demo/ac_intro_demo.c
+++ b/src/overlays/actors/ovl_Intro_Demo/ac_intro_demo.c
@@ -1,5 +1,7 @@
 #include "ac_intro_demo.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aID_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Kago/ac_kago.c
+++ b/src/overlays/actors/ovl_Kago/ac_kago.c
@@ -1,4 +1,6 @@
 #include "ac_kago.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aKAG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Kamakura/ac_kamakura.c
+++ b/src/overlays/actors/ovl_Kamakura/ac_kamakura.c
@@ -1,4 +1,6 @@
 #include "ac_kamakura.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aKKR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Kamakura_Indoor/ac_kamakura_indoor.c
+++ b/src/overlays/actors/ovl_Kamakura_Indoor/ac_kamakura_indoor.c
@@ -1,4 +1,6 @@
 #include "ac_kamakura_indoor.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Kamakura_Indoor_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Kamakura_Npc0/ac_kamakura_npc0.c
+++ b/src/overlays/actors/ovl_Kamakura_Npc0/ac_kamakura_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_kamakura_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aKM0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
+++ b/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
@@ -1,4 +1,6 @@
 #include "ac_koinobori.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aKOI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Lamp_Light/ef_lamp_light.c
+++ b/src/overlays/actors/ovl_Lamp_Light/ef_lamp_light.c
@@ -1,5 +1,7 @@
 #include "ef_lamp_light.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Ef_Lamp_Light_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Lotus/ac_lotus.c
+++ b/src/overlays/actors/ovl_Lotus/ac_lotus.c
@@ -1,5 +1,7 @@
 #include "ac_lotus.h"
 #include "m_collision_obj.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aLOT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_MailBox/ac_mailbox.c
+++ b/src/overlays/actors/ovl_MailBox/ac_mailbox.c
@@ -1,5 +1,7 @@
 #include "ac_mailbox.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aMBX_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Mbg/ac_mbg.c
+++ b/src/overlays/actors/ovl_Mbg/ac_mbg.c
@@ -1,4 +1,6 @@
 #include "ac_mbg.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Mbg_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Mikanbox/ac_mikanbox.c
+++ b/src/overlays/actors/ovl_Mikanbox/ac_mikanbox.c
@@ -1,4 +1,6 @@
 #include "ac_mikanbox.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805b3010(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Mikuji/ac_mikuji.c
+++ b/src/overlays/actors/ovl_Mikuji/ac_mikuji.c
@@ -1,4 +1,6 @@
 #include "ac_mikuji.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805b414c(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_MyHouse/ac_my_house.c
+++ b/src/overlays/actors/ovl_MyHouse/ac_my_house.c
@@ -1,4 +1,6 @@
 #include "ac_my_house.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80A05D50_jp(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_My_Indoor/ac_my_indoor.c
+++ b/src/overlays/actors/ovl_My_Indoor/ac_my_indoor.c
@@ -1,4 +1,6 @@
 #include "ac_my_indoor.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void My_Indoor_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_My_Room/ac_my_room.c
+++ b/src/overlays/actors/ovl_My_Room/ac_my_room.c
@@ -1,4 +1,6 @@
 #include "ac_my_room.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void My_Room_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Nameplate/ac_nameplate.c
+++ b/src/overlays/actors/ovl_Nameplate/ac_nameplate.c
@@ -1,4 +1,6 @@
 #include "ac_nameplate.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80A963C0_jp(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Normal_Npc/ac_normal_npc.c
+++ b/src/overlays/actors/ovl_Normal_Npc/ac_normal_npc.c
@@ -1,5 +1,7 @@
 #include "ac_normal_npc.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNOR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc/ac_npc.c
+++ b/src/overlays/actors/ovl_Npc/ac_npc.c
@@ -1,5 +1,7 @@
 #include "ac_npc.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_8053a354(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc2/ac_npc2.c
+++ b/src/overlays/actors/ovl_Npc2/ac_npc2.c
@@ -1,5 +1,7 @@
 #include "ac_npc2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80545034(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Conv_Master/ac_npc_conv_master.c
+++ b/src/overlays/actors/ovl_Npc_Conv_Master/ac_npc_conv_master.c
@@ -1,5 +1,7 @@
 #include "ac_npc_conv_master.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNCM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Depart_Master/ac_npc_depart_master.c
+++ b/src/overlays/actors/ovl_Npc_Depart_Master/ac_npc_depart_master.c
@@ -1,5 +1,7 @@
 #include "ac_npc_depart_master.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNDM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Engineer/ac_npc_engineer.c
+++ b/src/overlays/actors/ovl_Npc_Engineer/ac_npc_engineer.c
@@ -1,5 +1,7 @@
 #include "ac_npc_engineer.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNEG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Guide/ac_npc_guide.c
+++ b/src/overlays/actors/ovl_Npc_Guide/ac_npc_guide.c
@@ -1,5 +1,7 @@
 #include "ac_npc_guide.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNGD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Guide2/ac_npc_guide2.c
+++ b/src/overlays/actors/ovl_Npc_Guide2/ac_npc_guide2.c
@@ -1,5 +1,7 @@
 #include "ac_npc_guide2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNG2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Majin/ovl_Npc_Majin.c
+++ b/src/overlays/actors/ovl_Npc_Majin/ovl_Npc_Majin.c
@@ -1,5 +1,7 @@
 #include "ovl_Npc_Majin.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aMJN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Majin2/ac_npc_majin.c
+++ b/src/overlays/actors/ovl_Npc_Majin2/ac_npc_majin.c
@@ -1,5 +1,7 @@
 #include "ac_npc_majin.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aMJN2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Majin3/ac_npc_majin3.c
+++ b/src/overlays/actors/ovl_Npc_Majin3/ac_npc_majin3.c
@@ -1,5 +1,7 @@
 #include "ac_npc_majin3.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aMJN3_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Majin4/ac_npc_majin4.c
+++ b/src/overlays/actors/ovl_Npc_Majin4/ac_npc_majin4.c
@@ -1,5 +1,7 @@
 #include "ac_npc_majin4.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aMJN4_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Majin5/ac_npc_majin5.c
+++ b/src/overlays/actors/ovl_Npc_Majin5/ac_npc_majin5.c
@@ -1,5 +1,7 @@
 #include "ac_npc_majin5.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNMJ5_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Mamedanuki/ac_npc_mamedanuki.c
+++ b/src/overlays/actors/ovl_Npc_Mamedanuki/ac_npc_mamedanuki.c
@@ -1,5 +1,7 @@
 #include "ac_npc_mamedanuki.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNMD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_P_Sel/ac_npc_p_sel.c
+++ b/src/overlays/actors/ovl_Npc_P_Sel/ac_npc_p_sel.c
@@ -1,5 +1,7 @@
 #include "ac_npc_p_sel.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNPS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_P_Sel2/ac_npc_p_sel2.c
+++ b/src/overlays/actors/ovl_Npc_P_Sel2/ac_npc_p_sel2.c
@@ -1,5 +1,7 @@
 #include "ac_npc_p_sel2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNPS2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Police/ac_npc_police.c
+++ b/src/overlays/actors/ovl_Npc_Police/ac_npc_police.c
@@ -1,5 +1,7 @@
 #include "ac_npc_police.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPOL_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Police2/ac_npc_police2.c
+++ b/src/overlays/actors/ovl_Npc_Police2/ac_npc_police2.c
@@ -1,5 +1,7 @@
 #include "ac_npc_police2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPOL2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Post_Girl/ac_npc_post_girl.c
+++ b/src/overlays/actors/ovl_Npc_Post_Girl/ac_npc_post_girl.c
@@ -1,5 +1,7 @@
 #include "ac_npc_post_girl.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Post_Man/ac_npc_post_man.c
+++ b/src/overlays/actors/ovl_Npc_Post_Man/ac_npc_post_man.c
@@ -1,5 +1,7 @@
 #include "ac_npc_post_man.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPMAN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Rcn_Guide/ac_npc_rcn_guide.c
+++ b/src/overlays/actors/ovl_Npc_Rcn_Guide/ac_npc_rcn_guide.c
@@ -1,5 +1,7 @@
 #include "ac_npc_rcn_guide.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNRG_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Rcn_Guide2/ac_npc_rcn_guide2.c
+++ b/src/overlays/actors/ovl_Npc_Rcn_Guide2/ac_npc_rcn_guide2.c
@@ -1,5 +1,7 @@
 #include "ac_npc_rcn_guide2.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNRG2_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Restart/ac_npc_restart.c
+++ b/src/overlays/actors/ovl_Npc_Restart/ac_npc_restart.c
@@ -1,5 +1,7 @@
 #include "ac_npc_restart.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNRST_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Rtc/ac_npc_rtc.c
+++ b/src/overlays/actors/ovl_Npc_Rtc/ac_npc_rtc.c
@@ -1,5 +1,7 @@
 #include "ac_npc_rtc.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNRTC_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Shop_Master/ac_npc_shop_master.c
+++ b/src/overlays/actors/ovl_Npc_Shop_Master/ac_npc_shop_master.c
@@ -1,5 +1,7 @@
 #include "ac_npc_shop_master.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNSM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Shop_Mastersp/ac_npc_shop_mastersp.c
+++ b/src/overlays/actors/ovl_Npc_Shop_Mastersp/ac_npc_shop_mastersp.c
@@ -1,5 +1,7 @@
 #include "ac_npc_shop_mastersp.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSHM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Sleep_Obaba/ac_npc_sleep_obaba.c
+++ b/src/overlays/actors/ovl_Npc_Sleep_Obaba/ac_npc_sleep_obaba.c
@@ -1,5 +1,7 @@
 #include "ac_npc_sleep_obaba.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNSO_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Station_Master/ac_npc_station_master.c
+++ b/src/overlays/actors/ovl_Npc_Station_Master/ac_npc_station_master.c
@@ -1,5 +1,7 @@
 #include "ac_npc_station_master.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSTM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Super_Master/ac_npc_super_master.c
+++ b/src/overlays/actors/ovl_Npc_Super_Master/ac_npc_super_master.c
@@ -1,5 +1,7 @@
 #include "ac_npc_super_master.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNSPM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Npc_Totakeke/ac_npc_totakeke.c
+++ b/src/overlays/actors/ovl_Npc_Totakeke/ac_npc_totakeke.c
@@ -1,5 +1,7 @@
 #include "ac_npc_totakeke.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aNTT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Police_Box/ac_police_box.c
+++ b/src/overlays/actors/ovl_Police_Box/ac_police_box.c
@@ -1,4 +1,6 @@
 #include "ac_police_box.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPBOX_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Post_Office/ac_post_office.c
+++ b/src/overlays/actors/ovl_Post_Office/ac_post_office.c
@@ -1,4 +1,6 @@
 #include "ac_post_office.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPOFF_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Psnowman/ac_psnowman.c
+++ b/src/overlays/actors/ovl_Psnowman/ac_psnowman.c
@@ -1,4 +1,6 @@
 #include "ac_psnowman.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aPSM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Quest_Manager/ac_quest_manager.c
+++ b/src/overlays/actors/ovl_Quest_Manager/ac_quest_manager.c
@@ -1,5 +1,7 @@
 #include "ac_quest_manager.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aQMgr_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Radio/ac_radio.c
+++ b/src/overlays/actors/ovl_Radio/ac_radio.c
@@ -1,4 +1,6 @@
 #include "ac_radio.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aRAD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Reserve/ac_reserve.c
+++ b/src/overlays/actors/ovl_Reserve/ac_reserve.c
@@ -1,4 +1,6 @@
 #include "ac_reserve.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aRSV_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Ride_Off_Demo/ac_ride_off_demo.c
+++ b/src/overlays/actors/ovl_Ride_Off_Demo/ac_ride_off_demo.c
@@ -1,5 +1,7 @@
 #include "ac_ride_off_demo.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aROD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Room_Sunshine/ef_room_sunshine.c
+++ b/src/overlays/actors/ovl_Room_Sunshine/ef_room_sunshine.c
@@ -1,5 +1,7 @@
 #include "ef_room_sunshine.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Ef_Room_Sunshine_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Room_Sunshine_Police/ef_room_sunshine_police.c
+++ b/src/overlays/actors/ovl_Room_Sunshine_Police/ef_room_sunshine_police.c
@@ -1,5 +1,7 @@
 #include "ef_room_sunshine_police.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Ef_Room_Sunshine_Police_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Room_Sunshine_Posthouse/ef_room_sunshine_posthouse.c
+++ b/src/overlays/actors/ovl_Room_Sunshine_Posthouse/ef_room_sunshine_posthouse.c
@@ -1,5 +1,7 @@
 #include "ef_room_sunshine_posthouse.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Ef_Room_Sunshine_Posthouse_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Rope/ac_rope.c
+++ b/src/overlays/actors/ovl_Rope/ac_rope.c
@@ -1,5 +1,7 @@
 #include "ac_rope.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aRP_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_S_Car/ac_s_car.c
+++ b/src/overlays/actors/ovl_S_Car/ac_s_car.c
@@ -1,4 +1,6 @@
 #include "ac_s_car.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSCR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Sample/ac_sample.c
+++ b/src/overlays/actors/ovl_Sample/ac_sample.c
@@ -1,4 +1,6 @@
 #include "ac_sample.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Ac_Sample_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Set_Manager/ac_set_manager.c
+++ b/src/overlays/actors/ovl_Set_Manager/ac_set_manager.c
@@ -1,5 +1,7 @@
 #include "ac_set_manager.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSetMgr_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Set_Npc_Manager/ac_set_npc_manager.c
+++ b/src/overlays/actors/ovl_Set_Npc_Manager/ac_set_npc_manager.c
@@ -1,5 +1,7 @@
 #include "ac_set_npc_manager.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSNMgr_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop/ac_shop.c
+++ b/src/overlays/actors/ovl_Shop/ac_shop.c
@@ -1,4 +1,6 @@
 #include "ac_shop.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSHOP_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Design/ac_shop_design.c
+++ b/src/overlays/actors/ovl_Shop_Design/ac_shop_design.c
@@ -1,4 +1,6 @@
 #include "ac_shop_design.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Design_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Goods/ac_shop_goods.c
+++ b/src/overlays/actors/ovl_Shop_Goods/ac_shop_goods.c
@@ -1,4 +1,6 @@
 #include "ac_shop_goods.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Goods_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Indoor/ac_shop_indoor.c
+++ b/src/overlays/actors/ovl_Shop_Indoor/ac_shop_indoor.c
@@ -1,4 +1,6 @@
 #include "ac_shop_indoor.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Indoor_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Level/ac_shop_level.c
+++ b/src/overlays/actors/ovl_Shop_Level/ac_shop_level.c
@@ -1,4 +1,6 @@
 #include "ac_shop_level.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Level_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Manekin/ac_shop_manekin.c
+++ b/src/overlays/actors/ovl_Shop_Manekin/ac_shop_manekin.c
@@ -1,4 +1,6 @@
 #include "ac_shop_manekin.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Manekin_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shop_Umbrella/ac_shop_umbrella.c
+++ b/src/overlays/actors/ovl_Shop_Umbrella/ac_shop_umbrella.c
@@ -1,4 +1,6 @@
 #include "ac_shop_umbrella.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Shop_Umbrella_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Shrine/ac_shrine.c
+++ b/src/overlays/actors/ovl_Shrine/ac_shrine.c
@@ -1,4 +1,6 @@
 #include "ac_shrine.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSHR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Snowman/ac_snowman.c
+++ b/src/overlays/actors/ovl_Snowman/ac_snowman.c
@@ -1,4 +1,6 @@
 #include "ac_snowman.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSMAN_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Station/ac_station.c
+++ b/src/overlays/actors/ovl_Station/ac_station.c
@@ -1,4 +1,6 @@
 #include "ac_station.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSTA_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Structure/ac_structure.c
+++ b/src/overlays/actors/ovl_Structure/ac_structure.c
@@ -1,5 +1,7 @@
 #include "ac_structure.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSTR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Super/ac_super.c
+++ b/src/overlays/actors/ovl_Super/ac_super.c
@@ -1,4 +1,6 @@
 #include "ac_super.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aSPR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Cracker/ac_t_cracker.c
+++ b/src/overlays/actors/ovl_T_Cracker/ac_t_cracker.c
@@ -1,5 +1,7 @@
 #include "ac_t_cracker.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTCR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Flag/ac_t_flag.c
+++ b/src/overlays/actors/ovl_T_Flag/ac_t_flag.c
@@ -1,5 +1,7 @@
 #include "ac_t_flag.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTFL_actor_draw(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Hanabi/ac_t_hanabi.c
+++ b/src/overlays/actors/ovl_T_Hanabi/ac_t_hanabi.c
@@ -1,4 +1,6 @@
 #include "ac_t_hanabi.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTHB_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
+++ b/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
@@ -1,5 +1,7 @@
 #include "ac_t_keitai.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTKT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_NpcSao/ac_t_npc_sao.c
+++ b/src/overlays/actors/ovl_T_NpcSao/ac_t_npc_sao.c
@@ -1,5 +1,7 @@
 #include "ac_t_npc_sao.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTNS_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Pistol/ac_t_pistol.c
+++ b/src/overlays/actors/ovl_T_Pistol/ac_t_pistol.c
@@ -1,5 +1,7 @@
 #include "ac_t_pistol.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTPT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Tama/ac_t_tam.c
+++ b/src/overlays/actors/ovl_T_Tama/ac_t_tam.c
@@ -1,5 +1,7 @@
 #include "ac_t_tam.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTTM_actor_draw(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Tumbler/ac_t_tumbler.c
+++ b/src/overlays/actors/ovl_T_Tumbler/ac_t_tumbler.c
@@ -1,5 +1,7 @@
 #include "ac_t_tumbler.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTTB_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Umbrella/ac_t_umbrella.c
+++ b/src/overlays/actors/ovl_T_Umbrella/ac_t_umbrella.c
@@ -1,5 +1,7 @@
 #include "ac_t_umbrella.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTUMB_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_T_Utiwa/ac_t_utiwa.c
+++ b/src/overlays/actors/ovl_T_Utiwa/ac_t_utiwa.c
@@ -1,5 +1,7 @@
 #include "ac_t_utiwa.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTUT_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Taisou_Npc0/ac_taisou_npc0.c
+++ b/src/overlays/actors/ovl_Taisou_Npc0/ac_taisou_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_taisou_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTS0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tama/ac_tama.c
+++ b/src/overlays/actors/ovl_Tama/ac_tama.c
@@ -1,4 +1,6 @@
 #include "ac_tama.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTAM_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tamaire_Npc0/ac_tamaire_npc0.c
+++ b/src/overlays/actors/ovl_Tamaire_Npc0/ac_tamaire_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_tamaire_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTMN0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tamaire_Npc1/ac_tamaire_npc1.c
+++ b/src/overlays/actors/ovl_Tamaire_Npc1/ac_tamaire_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_tamaire_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTMN1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tokyoso_Control/ac_tokyoso_control.c
+++ b/src/overlays/actors/ovl_Tokyoso_Control/ac_tokyoso_control.c
@@ -1,5 +1,7 @@
 #include "ac_tokyoso_control.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTKC_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tokyoso_Npc0/ac_tokyoso_npc0.c
+++ b/src/overlays/actors/ovl_Tokyoso_Npc0/ac_tokyoso_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_tokyoso_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTKN0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tokyoso_Npc1/ac_tokyoso_npc1.c
+++ b/src/overlays/actors/ovl_Tokyoso_Npc1/ac_tokyoso_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_tokyoso_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTKN1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tools/ac_tools.c
+++ b/src/overlays/actors/ovl_Tools/ac_tools.c
@@ -1,5 +1,7 @@
 #include "ac_tools.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTOL_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Toudai/ac_toudai.c
+++ b/src/overlays/actors/ovl_Toudai/ac_toudai.c
@@ -1,4 +1,6 @@
 #include "ac_toudai.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTOU_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Train0/ac_train0.c
+++ b/src/overlays/actors/ovl_Train0/ac_train0.c
@@ -1,4 +1,6 @@
 #include "ac_train0.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805bfc28(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Train1/ac_train1.c
+++ b/src/overlays/actors/ovl_Train1/ac_train1.c
@@ -1,4 +1,6 @@
 #include "ac_train1.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTR1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_TrainDoor/ac_train_door.c
+++ b/src/overlays/actors/ovl_TrainDoor/ac_train_door.c
@@ -1,4 +1,6 @@
 #include "ac_train_door.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTRD_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Train_Window/ac_train_window.c
+++ b/src/overlays/actors/ovl_Train_Window/ac_train_window.c
@@ -1,4 +1,6 @@
 #include "ac_train_window.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Train_Window_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tukimi/ac_tukimi.c
+++ b/src/overlays/actors/ovl_Tukimi/ac_tukimi.c
@@ -1,4 +1,6 @@
 #include "ac_tukimi.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTUK_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tukimi_Npc0/ac_tukimi_npc0.c
+++ b/src/overlays/actors/ovl_Tukimi_Npc0/ac_tukimi_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_tukimi_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTM0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tukimi_Npc1/ac_tukimi_npc1.c
+++ b/src/overlays/actors/ovl_Tukimi_Npc1/ac_tukimi_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_tukimi_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTM1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tunahiki_Control/ac_tunahiki_control.c
+++ b/src/overlays/actors/ovl_Tunahiki_Control/ac_tunahiki_control.c
@@ -1,5 +1,7 @@
 #include "ac_tunahiki_control.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTNC_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tunahiki_Npc0/ac_tunahiki_npc0.c
+++ b/src/overlays/actors/ovl_Tunahiki_Npc0/ac_tunahiki_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_tunahiki_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTNN0_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Tunahiki_Npc1/ac_tunahiki_npc1.c
+++ b/src/overlays/actors/ovl_Tunahiki_Npc1/ac_tunahiki_npc1.c
@@ -1,5 +1,7 @@
 #include "ac_tunahiki_npc1.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTNN1_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Turi/ac_turi.c
+++ b/src/overlays/actors/ovl_Turi/ac_turi.c
@@ -1,4 +1,6 @@
 #include "ac_turi.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aTUR_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Turi_Npc0/ac_turi_npc0.c
+++ b/src/overlays/actors/ovl_Turi_Npc0/ac_turi_npc0.c
@@ -1,5 +1,7 @@
 #include "ac_turi_npc0.h"
 #include "m_lib.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_805900b0(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Uki/ac_uki.c
+++ b/src/overlays/actors/ovl_Uki/ac_uki.c
@@ -1,4 +1,6 @@
 #include "ac_uki.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aUKI_actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Weather/ac_weather.c
+++ b/src/overlays/actors/ovl_Weather/ac_weather.c
@@ -1,4 +1,6 @@
 #include "ac_weather.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Weather_Actor_ct(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Windmill/ac_windmil.c
+++ b/src/overlays/actors/ovl_Windmill/ac_windmil.c
@@ -1,4 +1,6 @@
 #include "ac_windmil.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void func_80A9C3C0_jp(Actor* thisx, Game_Play* game_play);

--- a/src/overlays/actors/ovl_Yatai/ac_yatai.c
+++ b/src/overlays/actors/ovl_Yatai/ac_yatai.c
@@ -1,4 +1,6 @@
 #include "ac_yatai.h"
+#include "m_actor_dlftbls.h"
+#include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void aYAT_actor_ct(Actor* thisx, Game_Play* game_play);


### PR DESCRIPTION
When bootstrapping the actors I didn't notice I was missing the headers for the actorid enum and the object id enum.