### PR TITLE
ac_tools OK

### DIFF
--- a/include/m_common_data.h
+++ b/include/m_common_data.h
@@ -15,6 +15,7 @@
 #include "m_quest.h"
 #include "unk.h"
 #include "m_snowman.h"
+#include "overlays/actors/ovl_Tools/ac_tools.h"
 
 struct Actor;
 struct ActorOverlay;
@@ -211,7 +212,9 @@ typedef struct CommonData {
     /* 0x10078 */ CommonData_unk_10078 *unk_10078;
     /* 0x1007C */ UNK_TYPE1 unk_1007C[0x1C];
     /* 0x10098 */ CommonData_unk_10098 *unk_10098;
-    /* 0x1009C */ UNK_TYPE1 unk_1009C[0x48];
+    /* 0x1009C */ UNK_TYPE1 unk_1009C[0x4];
+    /* 0x100A0 */ ToolClip* toolClip;
+    /* 0x100A4 */ UNK_TYPE1 unk_100A4[0x40];
     /* 0x100E4 */ CommonData_100E4_Func* unk_100E4;
     /* 0x100E8 */ u8 unk100E8[0x24];
     /* 0x1010C */ Time_c time;

--- a/include/m_common_data.h
+++ b/include/m_common_data.h
@@ -15,7 +15,6 @@
 #include "m_quest.h"
 #include "unk.h"
 #include "m_snowman.h"
-#include "overlays/actors/ovl_Tools/ac_tools.h"
 
 struct Actor;
 struct ActorOverlay;
@@ -24,6 +23,7 @@ struct ObjectStatus;
 struct CommonData_unk_1004C_unk_14_arg0;
 struct Game_Play;
 struct struct_809AEFA4;
+struct ToolClip;
 
 typedef UNK_RET (*CommonData_unk_1004C_unk_04)(struct ActorOverlay*, const struct struct_801161E8_jp*, size_t, s32);
 typedef UNK_RET (*CommonData_unk_1004C_unk_08)(void);
@@ -213,7 +213,7 @@ typedef struct CommonData {
     /* 0x1007C */ UNK_TYPE1 unk_1007C[0x1C];
     /* 0x10098 */ CommonData_unk_10098 *unk_10098;
     /* 0x1009C */ UNK_TYPE1 unk_1009C[0x4];
-    /* 0x100A0 */ ToolClip* toolClip;
+    /* 0x100A0 */ struct ToolClip* toolClip;
     /* 0x100A4 */ UNK_TYPE1 unk_100A4[0x40];
     /* 0x100E4 */ CommonData_100E4_Func* unk_100E4;
     /* 0x100E8 */ u8 unk100E8[0x24];

--- a/src/code/m_submenu.c
+++ b/src/code/m_submenu.c
@@ -15,6 +15,7 @@
 #include "attributes.h"
 #include "segment_symbols.h"
 #include "macros.h"
+#include "prevent_bss_reordering.h"
 
 #include "overlays/gamestates/ovl_play/m_play.h"
 #include "overlays/actors/player_actor/m_player.h"

--- a/src/overlays/actors/ovl_Tools/ac_tools.c
+++ b/src/overlays/actors/ovl_Tools/ac_tools.c
@@ -5,6 +5,7 @@
 #include "overlays/gamestates/ovl_play/m_play.h"
 #include "m_common_data.h"
 #include "m_scene.h"
+#include "macros.h"
 
 void aTOL_actor_ct(Actor* thisx, Game_Play* game_play);
 void aTOL_actor_dt(Actor* thisx, Game_Play* game_play);
@@ -15,11 +16,11 @@ ActorProfile Tools_Profile = {
     /* */ ACTOR_FLAG_10 | ACTOR_FLAG_20 | ACTOR_FLAG_20000000,
     /* */ 0x0000,
     /* */ GAMEPLAY_KEEP,
-    /* */ sizeof(Tools),
+    /* */ sizeof(Actor),
     /* */ aTOL_actor_ct,
     /* */ aTOL_actor_dt,
-    /* */ (ActorFunc)none_proc1,
-    /* */ (ActorFunc)none_proc1,
+    /* */ (void*)none_proc1,
+    /* */ (void*)none_proc1,
     /* */ NULL,
 };
 
@@ -48,8 +49,8 @@ s32 aTOL_check_data_bank(ObjectExchangeBank* objectExchangeBank, ToolName toolNa
         ObjectStatus* objectStatus = &objectExchangeBank->status[common_data.toolClip->umbrellaObjectIndex];
         Actor* temp_a0;
 
-        if (((objectStatus->id >= 0) ? (objectStatus->id) : (-objectStatus->id)) != objectIndex) {
-            u32 objectSize = gObjectTable[objectIndex].vromEnd - gObjectTable[objectIndex].vromStart;
+        if (ABS(objectStatus->id) != objectIndex) {
+            size_t objectSize = gObjectTable[objectIndex].vromEnd - gObjectTable[objectIndex].vromStart;
 
             if (objectSize <= 0xC00) {
                 temp_a0 = toolActor->actor.child;

--- a/src/overlays/actors/ovl_Tools/ac_tools.c
+++ b/src/overlays/actors/ovl_Tools/ac_tools.c
@@ -3,11 +3,12 @@
 #include "m_actor_dlftbls.h"
 #include "m_object.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
+#include "m_common_data.h"
+#include "m_scene.h"
 
 void aTOL_actor_ct(Actor* thisx, Game_Play* game_play);
 void aTOL_actor_dt(Actor* thisx, Game_Play* game_play);
 
-#if 0
 ActorProfile Tools_Profile = {
     /* */ ACTOR_TOOLS,
     /* */ ACTOR_PART_7,
@@ -21,20 +22,139 @@ ActorProfile Tools_Profile = {
     /* */ (ActorFunc)none_proc1,
     /* */ NULL,
 };
-#endif
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/aTOL_actor_ct.s")
+ToolClip aTOL_clip;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/aTOL_actor_dt.s")
+void aTOL_init_clip_area(Game_Play* game_play);
+void aTOL_free_clip_area(void);
+void aTOL_secure_pl_umbrella_bank_area(Game_Play* game_play);
+s32 aTOL_check_data_bank(ObjectExchangeBank* objectExchangeBank, ToolName toolName, ToolActor* toolActor,
+                         s16 objectIndex);
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_809657EC_jp.s")
+void aTOL_actor_ct(Actor* thisx UNUSED, Game_Play* game_play) {
+    aTOL_init_clip_area(game_play);
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_8096595C_jp.s")
+void aTOL_actor_dt(Actor* thisx UNUSED, Game_Play* game_play UNUSED) {
+    aTOL_free_clip_area();
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_80965A4C_jp.s")
+s32 aTOL_check_data_bank(ObjectExchangeBank* objectExchangeBank, ToolName toolName, ToolActor* toolActor,
+                         s16 objectIndex) {
+    s32 ret = -1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_80965A70_jp.s")
+    if ((toolActor->actor.part == ACTOR_PART_PLAYER) && (toolName <= TOOL_UMBRELLA31) &&
+        (common_data.toolClip->umbrellaObjectIndex != -1)) {
+        ObjectStatus* objectStatus = &objectExchangeBank->status[common_data.toolClip->umbrellaObjectIndex];
+        Actor* temp_a0;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_80965ACC_jp.s")
+        if (((objectStatus->id >= 0) ? (objectStatus->id) : (-objectStatus->id)) != objectIndex) {
+            u32 objectSize = gObjectTable[objectIndex].vromEnd - gObjectTable[objectIndex].vromStart;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/actors/ovl_Tools/ac_tools/func_80965B20_jp.s")
+            if (objectSize <= 0xC00) {
+                temp_a0 = toolActor->actor.child;
+
+                if ((temp_a0 != NULL) && (temp_a0->unk_026 == common_data.toolClip->umbrellaObjectIndex)) {
+                    Actor_delete(temp_a0);
+                }
+
+                objectStatus->id = -objectIndex;
+                objectStatus->vrom = gObjectTable[objectIndex].vromStart;
+                objectStatus->size = objectSize;
+                objectStatus->unk50 = 0;
+                objectStatus->unk53 = 1;
+                objectStatus->unk14 = 0;
+            }
+        } else {
+            ret = common_data.toolClip->umbrellaObjectIndex;
+        }
+    } else {
+        s32 temp_v0_2 = mSc_bank_regist_check(objectExchangeBank, objectIndex);
+
+        ret = temp_v0_2;
+
+        if (temp_v0_2 == -1) {
+            func_800C6144_jp(objectExchangeBank, objectIndex);
+        }
+    }
+
+    return ret;
+}
+
+ToolActor* aTOL_birth_proc(ToolName toolName, s32 arg1, ToolActor* toolActor, Game_Play* game_play, s16 params,
+                           s32* arg5) {
+    static s16 profile_table[] = {
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA,
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA,
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA,
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA,
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA,
+        ACTOR_T_UMBRELLA, ACTOR_T_UMBRELLA, ACTOR_T_KEITAI,   ACTOR_T_UTIWA,    ACTOR_T_HANABI,   ACTOR_T_CRACKER,
+        ACTOR_T_PISTOL,   ACTOR_T_FLAG,     ACTOR_T_TUMBLER,  ACTOR_T_NPC_SAO,  ACTOR_T_TAMA,     ACTOR_T_TAMA,
+        ACTOR_T_TAMA,     ACTOR_T_TAMA,
+    };
+    static s16 objectTable[] = {
+        OBJECT_28, OBJECT_85, OBJECT_72,  OBJECT_73,  OBJECT_74,  OBJECT_75,  OBJECT_76,  OBJECT_77,  OBJECT_78,
+        OBJECT_79, OBJECT_80, OBJECT_81,  OBJECT_82,  OBJECT_83,  OBJECT_84,  OBJECT_55,  OBJECT_56,  OBJECT_57,
+        OBJECT_58, OBJECT_59, OBJECT_60,  OBJECT_61,  OBJECT_62,  OBJECT_63,  OBJECT_64,  OBJECT_65,  OBJECT_66,
+        OBJECT_67, OBJECT_68, OBJECT_69,  OBJECT_70,  OBJECT_71,  OBJECT_45,  OBJECT_53,  OBJECT_53,  OBJECT_395,
+        OBJECT_16, OBJECT_6,  OBJECT_371, OBJECT_370, OBJECT_391, OBJECT_391, OBJECT_391, OBJECT_391,
+    };
+    s32 pad[3] UNUSED;
+    ToolActor* ret = NULL;
+    s32 temp_v0 = aTOL_check_data_bank(&game_play->objectExchangeBank, toolName, toolActor, objectTable[toolName]);
+    s32 pad2 UNUSED;
+
+    if (temp_v0 != -1) {
+        ret = (ToolActor*)Actor_info_make_child_actor(&game_play->actorInfo, &toolActor->actor, game_play,
+                                                      profile_table[toolName], 0.0f, 0.0f, 0.0f, 0, 0, 0, -1, 0, params,
+                                                      temp_v0);
+        if (ret != NULL) {
+            ret->unk1BC = arg1;
+            ret->toolName = toolName;
+        }
+    }
+
+    if (arg5 != NULL) {
+        *arg5 = temp_v0;
+    }
+
+    return ret;
+}
+
+s32 aTOL_chg_request_mode_proc(Actor* arg0, ToolActor* toolActor, s32 arg2) {
+    if (arg0 != toolActor->actor.parent) {
+        return 0;
+
+    } else {
+        toolActor->unk1BC = arg2;
+        return 1;
+    }
+}
+
+void aTOL_secure_pl_umbrella_bank_area(Game_Play* game_play) {
+    s32 pad UNUSED;
+    s32 sp18 = game_play->objectExchangeBank.num;
+
+    if (mSc_secure_exchange_keep_bank(&game_play->objectExchangeBank, 0, 0xC00)) {
+        common_data.toolClip->umbrellaObjectIndex = sp18;
+
+    } else {
+        common_data.toolClip->umbrellaObjectIndex = -1;
+    }
+}
+
+void aTOL_init_clip_area(Game_Play* game_play) {
+    if (common_data.toolClip == NULL) {
+        common_data.toolClip = &aTOL_clip;
+        common_data.toolClip->aTOL_birth_proc = &aTOL_birth_proc;
+        common_data.toolClip->aTOL_chg_request_mode_proc = &aTOL_chg_request_mode_proc;
+        aTOL_secure_pl_umbrella_bank_area(game_play);
+    }
+}
+
+void aTOL_free_clip_area(void) {
+    if (common_data.toolClip) {
+        common_data.toolClip = NULL;
+    }
+}

--- a/src/overlays/actors/ovl_Tools/ac_tools.h
+++ b/src/overlays/actors/ovl_Tools/ac_tools.h
@@ -14,4 +14,67 @@ typedef struct Tools {
     /* 0x000 */ Actor actor;
 } Tools; // size = 0x174
 
+typedef enum ToolName {
+    /* 0x00 */ TOOL_UMBRELLA0,
+    /* 0x01 */ TOOL_UMBRELLA1,
+    /* 0x02 */ TOOL_UMBRELLA2,
+    /* 0x03 */ TOOL_UMBRELLA3,
+    /* 0x04 */ TOOL_UMBRELLA4,
+    /* 0x05 */ TOOL_UMBRELLA5,
+    /* 0x06 */ TOOL_UMBRELLA6,
+    /* 0x07 */ TOOL_UMBRELLA7,
+    /* 0x08 */ TOOL_UMBRELLA8,
+    /* 0x09 */ TOOL_UMBRELLA9,
+    /* 0x0A */ TOOL_UMBRELLA10,
+    /* 0x0B */ TOOL_UMBRELLA11,
+    /* 0x0C */ TOOL_UMBRELLA12,
+    /* 0x0D */ TOOL_UMBRELLA13,
+    /* 0x0E */ TOOL_UMBRELLA14,
+    /* 0x0F */ TOOL_UMBRELLA15,
+    /* 0x10 */ TOOL_UMBRELLA16,
+    /* 0x11 */ TOOL_UMBRELLA17,
+    /* 0x12 */ TOOL_UMBRELLA18,
+    /* 0x13 */ TOOL_UMBRELLA19,
+    /* 0x14 */ TOOL_UMBRELLA20,
+    /* 0x15 */ TOOL_UMBRELLA21,
+    /* 0x16 */ TOOL_UMBRELLA22,
+    /* 0x17 */ TOOL_UMBRELLA23,
+    /* 0x18 */ TOOL_UMBRELLA24,
+    /* 0x19 */ TOOL_UMBRELLA25,
+    /* 0x1A */ TOOL_UMBRELLA26,
+    /* 0x1B */ TOOL_UMBRELLA27,
+    /* 0x1C */ TOOL_UMBRELLA28,
+    /* 0x1D */ TOOL_UMBRELLA29,
+    /* 0x1E */ TOOL_UMBRELLA30,
+    /* 0x1F */ TOOL_UMBRELLA31,
+    /* 0x20 */ TOOL_KEITAI,
+    /* 0x21 */ TOOL_UTIWA,
+    /* 0x22 */ TOOL_HANABI,
+    /* 0x23 */ TOOL_CRACKER,
+    /* 0x24 */ TOOL_PISTOL,
+    /* 0x25 */ TOOL_FLAG,
+    /* 0x26 */ TOOL_TUMBLER,
+    /* 0x27 */ TOOL_NPC_SAO,
+    /* 0x28 */ TOOL_TAMA1,
+    /* 0x29 */ TOOL_TAMA2,
+    /* 0x2A */ TOOL_TAMA3,
+    /* 0x2B */ TOOL_TAMA4
+} ToolName;
+
+typedef struct ToolActor {
+    /* 0x000 */ Actor actor;
+    /* 0x174 */ ToolName toolName;
+    /* 0x178 */ UNK_TYPE1 unk178[0x44];
+    /* 0x1BC */ UNK_TYPE unk1BC;
+} ToolActor; // size >= 0x1C0
+
+typedef ToolActor* (*ToolBirthProc)(ToolName, s32, ToolActor*, struct Game_Play*, s16, s32*);
+typedef s32 (*ToolChgRequestModeProc)(Actor*, ToolActor*, s32);
+
+typedef struct ToolClip {
+    /* 0x00 */ ToolBirthProc aTOL_birth_proc;
+    /* 0x04 */ ToolChgRequestModeProc aTOL_chg_request_mode_proc;
+    /* 0x08 */ u32 umbrellaObjectIndex;
+} ToolClip; // size >= 0xC
+
 #endif

--- a/src/overlays/actors/ovl_Tools/ac_tools.h
+++ b/src/overlays/actors/ovl_Tools/ac_tools.h
@@ -6,13 +6,6 @@
 #include "unk.h"
 
 struct Game_Play;
-struct Tools;
-
-typedef void (*ToolsActionFunc)(struct Tools*, struct Game_Play*);
-
-typedef struct Tools {
-    /* 0x000 */ Actor actor;
-} Tools; // size = 0x174
 
 typedef enum ToolName {
     /* 0x00 */ TOOL_UMBRELLA0,

--- a/yamls/jp/overlays.yaml
+++ b/yamls/jp/overlays.yaml
@@ -1603,8 +1603,8 @@
     bss_size: 0x10
     subsegments:
       - [0x85A400, c, overlays/actors/ovl_Tools/ac_tools]
-      - [0x85A7A0, data, overlays/actors/ovl_Tools/ac_tools]
-      - { start: 0x85A880, type: bss, vram: 0x80965C20, name: overlays/actors/ovl_Tools/ac_tools }
+      - [0x85A7A0, .data, overlays/actors/ovl_Tools/ac_tools]
+      - { start: 0x85A880, type: .bss, vram: 0x80965C20, name: overlays/actors/ovl_Tools/ac_tools }
   - name: ovl_Tools_reloc
     type: code
     start: 0x85A880


### PR DESCRIPTION
This is a base class for other tool actors, miscellaneous handheld objects used by both the player and npcs.

It seems like these actors use a special actor struct, similar to how DynaPolyActors have a different struct as the first struct instead of just Actor. I named this ToolActor.

aTOL_clip is a collection of callbacks to helper functions that tool actors can use. I'm assuming other base class actors store other data in clips too, ac_tools uses this to keep track of the object index for umbrellas