### PR TITLE
Update `OPEN_DISPS` to include `do {} while (0)`

### DIFF
--- a/include/gfx.h
+++ b/include/gfx.h
@@ -47,7 +47,8 @@ typedef struct GraphicsContext {
 #define OPEN_DISPS(gfxCtx)                  \
     {                                       \
         GraphicsContext* __gfxCtx = gfxCtx; \
-        s32 __dispPad UNUSED
+        s32 __dispPad UNUSED;               \
+        do {} while (0)
 
 #define CLOSE_DISPS(gfxCtx) \
     (void)0;                \

--- a/src/overlays/actors/ovl_Mbg/ac_mbg.c
+++ b/src/overlays/actors/ovl_Mbg/ac_mbg.c
@@ -54,9 +54,8 @@ void Mbg_Actor_draw(Actor* thisx, Game_Play* game_play) {
     sp3C = thisx->world.pos;
     sp3A = thisx->shape.rot.y;
     OPEN_DISPS(game_play->state.gfxCtx);
-    if (1) {}
     _texture_z_light_fog_prim(game_play->state.gfxCtx);
-    Matrix_translate(sp3C.x, sp3C.y, sp3C.z, 0U);
+    Matrix_translate(sp3C.x, sp3C.y, sp3C.z, MTXMODE_NEW);
     Matrix_RotateY(sp3A, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, _Matrix_to_Mtx_new(game_play->state.gfxCtx),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);


### PR DESCRIPTION
We were doing a lot of discussion related to matching draw functions in the Discord, and I noticed that in AC GCN, they have a `while (0)` at the end of their `OPEN_DISP` macro. I copied that pattern here, and it actually fixes a weird match in `Mbg_Actor_draw` too. We've matched some more draw functions in various decomp.me scratches using this too, so I believe it's probably safe to introduce this into the repo proper.