### PR TITLE
common_data cleanup

### DIFF
--- a/include/6DB420.h
+++ b/include/6DB420.h
@@ -5,10 +5,10 @@
 #include "6B8A70.h"
 #include "unk.h"
 
-struct Private_c;
+struct PrivateInfo;
 struct mPr_map_info_c;
-struct mLd_land_info_c;
-struct mPr_mother_mail_info_c;
+struct LandInfo;
+struct MotherMailInfo;
 
 typedef struct PlayerName {
     /* 0x0 */ UNK_TYPE1 unk_0[0x6];
@@ -33,15 +33,15 @@ void mPr_CopyPersonalID(PersonalID* arg0, PersonalID* arg1);
 s32 mPr_CheckCmpPersonalID(PersonalID* arg0, PersonalID* arg1);
 // void func_800B7A94_jp();
 // void func_800B7AB0_jp();
-void mPr_ClearPrivateInfo(struct Private_c* private);
+void mPr_ClearPrivateInfo(struct PrivateInfo* private);
 // void func_800B7B8C_jp();
 // void func_800B7BC0_jp();
 // void func_800B7CD0_jp();
 // void func_800B7D50_jp();
-void mPr_InitPrivateInfo(struct Private_c* private);
+void mPr_InitPrivateInfo(struct PrivateInfo* private);
 // void func_800B7F00_jp();
 // void func_800B7F48_jp();
-s32 mPr_CheckPrivate(struct Private_c* private);
+s32 mPr_CheckPrivate(struct PrivateInfo* private);
 // void func_800B7FA0_jp();
 // void func_800B7FD4_jp();
 // void func_800B8068_jp();
@@ -56,7 +56,7 @@ s32 mPr_CheckPrivate(struct Private_c* private);
 // void func_800B86EC_jp();
 // void func_800B88EC_jp();
 // void func_800B8A88_jp();
-void mPr_SetPossessionItem(struct Private_c* priv, int idx, u16 item, u32 cond);
+void mPr_SetPossessionItem(struct PrivateInfo* priv, int idx, u16 item, u32 cond);
 // void func_800B8B8C_jp();
 // void func_800B8BE4_jp();
 // void func_800B8C10_jp();
@@ -66,7 +66,7 @@ void mPr_SetPossessionItem(struct Private_c* priv, int idx, u16 item, u32 cond);
 // void func_800B8D18_jp();
 // void func_800B8D3C_jp();
 s32 func_800B8D64_jp(u8 player_no, s32 arg1);
-void mPr_ClearMotherMailInfo(struct mPr_mother_mail_info_c* arg0);
+void mPr_ClearMotherMailInfo(struct MotherMailInfo* arg0);
 // void func_800B8F20_jp();
 // void func_800B8FB8_jp();
 // void func_800B9038_jp();
@@ -83,7 +83,7 @@ void mPr_ClearMotherMailInfo(struct mPr_mother_mail_info_c* arg0);
 // void func_800B9AF0_jp();
 void func_800B9B2C_jp(void);
 // void func_800B9C34_jp();
-void mPr_SendForeingerAnimalMail(struct Private_c* now_private);
+void mPr_SendForeingerAnimalMail(struct PrivateInfo* privateInfo);
 void mPr_StartSetCompleteTalkInfo(void);
 // void func_800B9E90_jp();
 // void func_800B9EB4_jp();
@@ -103,7 +103,7 @@ void mPr_StartSetCompleteTalkInfo(void);
 // void func_800BA2D4_jp();
 // void func_800BA344_jp();
 // void func_800BA3D0_jp();
-void mPr_RenewalMapInfo(struct mPr_map_info_c* maps, s32 count, struct mLd_land_info_c* land_info);
+void mPr_RenewalMapInfo(struct mPr_map_info_c* maps, s32 count, struct LandInfo* landInfo);
 // void mPr_RandomSetPlayerData_title_demo();
 // void mPr_PrintMapInfo_debug();
 

--- a/include/m_common_data.h
+++ b/include/m_common_data.h
@@ -27,26 +27,19 @@ struct ToolClip;
 
 typedef UNK_RET (*CommonData_unk_1004C_unk_04)(struct ActorOverlay*, const struct struct_801161E8_jp*, size_t, s32);
 typedef UNK_RET (*CommonData_unk_1004C_unk_08)(void);
-
-// TODO: figure out if this is a generic memory allocation or if it is Actor specific
 typedef UNK_PTR (*CommonData_unk_1004C_unk_0C)(size_t, const struct struct_801161E8_jp*, s32);
-
 typedef UNK_RET (*CommonData_unk_1004C_unk_10)(struct Actor*);
 typedef UNK_RET (*CommonData_unk_1004C_unk_14)(struct CommonData_unk_1004C_unk_14_arg0*, u16);
-
 typedef UNK_RET (*CommonData_unk_1004C_unk_BC)(struct Actor*, struct Game_Play*);
 typedef void (*CommonData_unk_1004C_unk_C0)(struct Actor*, struct Game_Play*, struct struct_809AEFA4*);
 typedef UNK_RET (*CommonData_unk_1004C_unk_C4)(struct Actor*, struct Game_Play*);
 typedef UNK_RET (*CommonData_unk_1004C_unk_C8)(struct Actor*, struct Game_Play*);
 typedef UNK_RET (*CommonData_unk_1004C_unk_CC)(struct Actor*, struct Game_Play*);
 typedef UNK_RET (*CommonData_unk_1004C_unk_D0)(void);
-
 typedef UNK_RET (*CommonData_unk_1004C_unk_E4)(void);
-
 typedef UNK_RET (*CommonData_unk_1004C_unk_EC)(struct ObjectStatus*, s16, s16);
 typedef UNK_RET (*CommonData_unk_1004C_unk_F0)(struct ObjectStatus*, struct Actor*);
 typedef s32 (*CommonData_unk_1004C_unk_F4)(struct ObjectStatus*, struct Actor*);
-
 typedef UNK_RET (*CommonData_unk_1004C_unk_118)(struct Actor*);
 
 typedef struct CommonData_unk_1004C {
@@ -77,7 +70,6 @@ typedef UNK_RET (*CommonData_unk_10078_unk_00)(UNK_TYPE);
 typedef UNK_RET (*CommonData_unk_10078_unk_04)(UNK_TYPE);
 typedef UNK_RET (*CommonData_unk_10078_unk_08)(UNK_TYPE);
 
-
 typedef struct CommonData_unk_10078 {
     /* 0x00 */ CommonData_unk_10078_unk_00 unk_00;
     /* 0x04 */ CommonData_unk_10078_unk_04 unk_04;
@@ -86,7 +78,6 @@ typedef struct CommonData_unk_10078 {
 
 typedef UNK_RET (*CommonData_unk_10098_unk_4)(struct ActorOverlay*, size_t);
 typedef UNK_RET (*CommonData_unk_10098_unk_8)(void);
-// TODO: figure out if this is a generic memory allocation or if it is Actor specific
 typedef UNK_PTR (*CommonData_unk_10098_unk_0C)(void);
 typedef UNK_RET (*CommonData_unk_10098_unk_10)(struct Actor*);
 typedef UNK_RET (*CommonData_unk_10098_unk_A8)(UNK_PTR, UNK_TYPE, u16 name, Actor* actor);
@@ -103,25 +94,25 @@ typedef struct CommonData_unk_10098 {
     /* 0x0A8 */ CommonData_unk_10098_unk_A8 unk_A8; // unload object
     /* 0x0AC */ CommonData_unk_10098_unk_AC unk_AC; // load object
     /* 0x0B0 */ UNK_TYPE unk_B0;
-    /* 0x0B4 */ UNK_TYPE1 pad[0x450-0xb4];
+    /* 0x0B4 */ UNK_TYPE1 pad[0x450 - 0xb4];
     /* 0x450 */ CommonData_unk_10098_unk_450 unk_450; // load palette
     /* 0x454 */ UNK_TYPE unk_454;
-    /* 0x458 */ UNK_TYPE1 pad2[0x86C-0x458];
+    /* 0x458 */ UNK_TYPE1 pad2[0x86C - 0x458];
     /* 0x86C */ UNK_TYPE unk_86C;
 } CommonData_unk_10098; // size >= 0x870
 
-typedef struct mPr_mother_mail_info_c {
+typedef struct MotherMailInfo {
     /* 0x00 */ UNK_TYPE1 unk_00[0xE];
-} mPr_mother_mail_info_c; // size = 0xE
+} MotherMailInfo; // size = 0xE
 
 typedef enum Season {
     /* 0 */ SPRING,
     /* 1 */ SUMMER,
     /* 2 */ FALL,
-    /* 3 */ WINTER,
+    /* 3 */ WINTER
 } Season;
 
-typedef struct Time_c {
+typedef struct Time {
     /* 0x00 */ u32 season;
     /* 0x04 */ u32 termIdx;
     /* 0x08 */ s16 bgitemProfile;
@@ -137,7 +128,7 @@ typedef struct Time_c {
     /* 0x20 */ s32 rtcEnabled;
     /* 0x24 */ s32 addSec;
     /* 0x28 */ s32 addIdx;
-} Time_c; // size = 0x2C
+} Time; // size = 0x2C
 
 typedef struct FamicomEmuCommonData {
     /* 0x00 */ s16 unk00;
@@ -159,70 +150,74 @@ typedef struct FamicomEmuCommonData {
     /* 0x20 */ s16 unk20;
     /* 0x22 */ s16 unk22;
     /* 0x24 */ s16 unk24;
-}FamicomEmuCommonData; // size >= 0x26
+} FamicomEmuCommonData; // size >= 0x26
 
-typedef void (*CommonData_100E4_Func)(struct Game_Play*);
+typedef void (*CommonData_100E4_unk_00)(struct Game_Play* game_play);
+
+typedef struct CommonData_unk_100E4 {
+    /* 0x00 */ CommonData_100E4_unk_00 unk_00;
+} CommonData_unk_100E4; // size >= 0x4
 
 typedef struct CommonData {
-    /* 0x00000 */ u8 unk00000[0x14];
+    /* 0x00000 */ u8 unk_00000[0x14];
     /* 0x00014 */ s32 unk_00014;
     /* 0x00018 */ u8 nowNpcMax;
     /* 0x00019 */ u8 removeAnimalIdx;
-    /* 0x0001A */ u8 unk1A[0x20 - 0x1A];
-    /* 0x00020 */ Private_c private[PLAYER_NUM]; /* player data */
-    /* 0x02F60 */ mLd_land_info_c land_info; /* town name & id */
-    /* 0x02F6A */ u8 unk02F6A[0x61E];
+    /* 0x0001A */ u8 unk_1A[0x20 - 0x1A];
+    /* 0x00020 */ PrivateInfo saveFilePrivateInfo[PLAYER_NUM]; // player data
+    /* 0x02F60 */ LandInfo landInfo; // town name & id
+    /* 0x02F6A */ u8 unk_02F6A[0x61E];
     /* 0x03588 */ mHm_hs_c homes[PLAYER_NUM];
-    /* 0x062A8 */ mFM_fg_c fg[FG_BLOCK_Z_NUM][FG_BLOCK_X_NUM]; /* fg items (fg = foreground?) */
-    /* 0x09EA8 */ u8 unk09EA8[0x70];
-    /* 0x09F18 */ Animal_c animals[ANIMAL_NUM_MAX]; /* villagers in town */
-    /* 0x0EC70 */ u8 unk0EC70[0x134];
+    /* 0x062A8 */ mFM_fg_c fg[FG_BLOCK_Z_NUM][FG_BLOCK_X_NUM]; // fg items (fg = foreground?)
+    /* 0x09EA8 */ u8 unk_09EA8[0x70];
+    /* 0x09F18 */ Animal_c animals[ANIMAL_NUM_MAX]; // villagers in town
+    /* 0x0EC70 */ u8 unk_0EC70[0x134];
     /* 0x0EDA4 */ mEv_event_save_c event_save_data;
-    /* 0x0EE40 */ u8 unk0EE40[0x118];
+    /* 0x0EE40 */ u8 unk_0EE40[0x118];
     /* 0x0EF58 */ u16 fruit;
     /* 0x0EF5A */ UNK_TYPE1 unk_0EF5A[0x12];
     /* 0x0EF6C */ Mail unk_0EF6C[5];
     /* 0x0F2A0 */ UNK_TYPE1 unk_0F2A0[0x17C];
     /* 0x0F41C */ SnowmanData snowmanData[SNOWMAN_SAVE_COUNT];
     /* 0x0F428 */ UNK_TYPE1 unk_F428[0x10];
-    /* 0x0F438 */ u8 station_type; /* train station type */
-    /* 0x0F439 */ u8 unk0F439[0x3];
-    /* 0x0F43C */ u16 deposit[FG_BLOCK_X_NUM * FG_BLOCK_Z_NUM][UT_Z_NUM]; /* flags for which items are buried around town */
+    /* 0x0F438 */ u8 stationType;
+    /* 0x0F439 */ u8 unk_F439[0x3];
+    /* 0x0F43C */ u16 deposit[FG_BLOCK_X_NUM * FG_BLOCK_Z_NUM][UT_Z_NUM]; // flags for which items are buried around town
     /* 0x0F7FC */ lbRTC_time_c unk_0F7FC;
-    /* 0x0F804 */ mPr_mother_mail_info_c mother_mail[PLAYER_NUM];
-    /* 0x0F83C */ u8 unk0F83C[0x8];
-    /* 0x0F844 */ FamicomEmuCommonData famicom_emu_common_data;
-    /* 0x0F86A */ u8 unk0F86A[0x32];
+    /* 0x0F804 */ MotherMailInfo motherMailInfo[PLAYER_NUM];
+    /* 0x0F83C */ u8 unk_0F83C[0x8];
+    /* 0x0F844 */ FamicomEmuCommonData famicomEmuCommonData;
+    /* 0x0F86A */ u8 unk_0F86A[0x32];
     /* 0x0F89C */ lbRTC_time_c unk_0F89C;
     /* 0x0F8A4 */ lbRTC_time_c unk_0F8A4;
-    /* 0x0F8AC */ UNK_TYPE1 unk0F8AC;
-    /* 0x0F8AD */ u8 snowmanYear; // Year last snowman was built.
+    /* 0x0F8AC */ UNK_TYPE1 unk_0F8AC;
+    /* 0x0F8AD */ u8 snowmanYear;  // Year last snowman was built.
     /* 0x0F8AE */ u8 snowmanMonth; // Month last snowman was built.
-    /* 0x0F8AF */ u8 snowmanDay; // Day last snowman was built.
-    /* 0x0F8B0 */ u8 snowmanHour; // Hour last snowman was built.
-    /* 0x0F8B1 */ UNK_TYPE1 unk0F8B1[0x74F];
+    /* 0x0F8AF */ u8 snowmanDay;   // Day last snowman was built.
+    /* 0x0F8B0 */ u8 snowmanHour;  // Hour last snowman was built.
+    /* 0x0F8B1 */ UNK_TYPE1 unk_0F8B1[0x74F];
     /* 0x10000 */ u8 unk_10000; // named "game_started" in AC GCN decomp
     /* 0x10001 */ u8 unk_10001;
-    /* 0x10002 */ u8 unk10002[0x1];
-    /* 0x10003 */ u8 player_no;
+    /* 0x10002 */ u8 unk_10002[0x1];
+    /* 0x10003 */ u8 playerNumber;
     /* 0x10004 */ s32 unk_10004; // named "last_scene_no" in AC GCN decomp
     /* 0x10008 */ UNK_TYPE1 unk_10008[0x44];
-    /* 0x1004C */ CommonData_unk_1004C *unk_1004C;
+    /* 0x1004C */ CommonData_unk_1004C* unk_1004C;
     /* 0x10050 */ UNK_TYPE1 unk_10050[0x28];
-    /* 0x10078 */ CommonData_unk_10078 *unk_10078;
+    /* 0x10078 */ CommonData_unk_10078* unk_10078;
     /* 0x1007C */ UNK_TYPE1 unk_1007C[0x1C];
-    /* 0x10098 */ CommonData_unk_10098 *unk_10098;
+    /* 0x10098 */ CommonData_unk_10098* unk_10098;
     /* 0x1009C */ UNK_TYPE1 unk_1009C[0x4];
     /* 0x100A0 */ struct ToolClip* toolClip;
     /* 0x100A4 */ UNK_TYPE1 unk_100A4[0x40];
-    /* 0x100E4 */ CommonData_100E4_Func* unk_100E4;
-    /* 0x100E8 */ u8 unk100E8[0x24];
-    /* 0x1010C */ Time_c time;
-    /* 0x10138 */ Private_c* now_private;
-    /* 0x1013C */ u8 unk1013C[0x4];
+    /* 0x100E4 */ CommonData_unk_100E4* unk_100E4;
+    /* 0x100E8 */ u8 unk_100E8[0x24];
+    /* 0x1010C */ Time time;
+    /* 0x10138 */ PrivateInfo* privateInfo;
+    /* 0x1013C */ u8 unk_1013C[0x4];
     /* 0x10140 */ u8 unk_10140;
     /* 0x10141 */ u8 fish_location;
-    /* 0x10142 */ u8 unk10142[0x7];
+    /* 0x10142 */ u8 unk_10142[0x7];
     /* 0x10149 */ u8 unk_10149;
     /* 0x1014A */ u8 unk_1014A;
     /* 0x1014B */ u8 unk_1014B; // named "wipeType" in AC GCN decomp
@@ -230,15 +225,15 @@ typedef struct CommonData {
     /* 0x1014E */ s16 unk_1014E;
     /* 0x10150 */ UNK_TYPE1 unk_10150[0x10];
     /* 0x10160 */ NpcList npclist[ANIMAL_NUM_MAX];
-    /* 0x104A8 */ u16 house_owner_name;
-    /* 0x104AA */ u16 last_field_id;
+    /* 0x104A8 */ u16 houseOwnerName;
+    /* 0x104AA */ u16 lastFieldId;
     /* 0x104AC */ UNK_TYPE1 unk_104AC[0x1];
     /* 0x104AD */ u8 unk_104AD;
     /* 0x104AE */ u8 unk_104AE;
     /* 0x104AF */ UNK_TYPE1 unk_104AF[0x1];
     /* 0x104B0 */ UNK_TYPE1 unk_104B0[0xE8];
     /* 0x10598 */ mQst_not_saved_c quest;
-    /* 0x105A0 */ u32 scene_from_title_demo;
+    /* 0x105A0 */ u32 sceneFromTitleDemo;
     /* 0x105A4 */ NpsSchedule npcSchedule[ANIMAL_NUM_MAX];
     /* 0x10694 */ NpcWalking npcWalk;
     /* 0x10710 */ UNK_TYPE1 unk_10710[0x3C];
@@ -249,12 +244,12 @@ typedef struct CommonData {
     /* 0x107A0 */ UNK_TYPE unk_107A0;
     /* 0x107A4 */ UNK_TYPE1 unk_107A4[0x12];
     /* 0x107B6 */ s16 unk_107B6; // named "demo_profile" in AC GCN decomp (though it's an array of two s16s in that game)
-    /* 0x107B8 */ u8 unk107B8[0x28];
+    /* 0x107B8 */ u8 unk_107B8[0x28];
     /* 0x107E0 */ s8 player_decoy_flag;
-    /* 0x107E1 */ u8 unk107E1[0x3];
+    /* 0x107E1 */ u8 unk_107E1[0x3];
     /* 0x107E4 */ s16 unk_107E4;
-    /* 0x107E6 */ u8 unk107E6[0x254];
-    /* 0x10A3A */ u8 goki_shocked_flag;
+    /* 0x107E6 */ u8 unk_107E6[0x254];
+    /* 0x10A3A */ u8 gokiShockedFlag;
     /* 0x10A3B */ UNK_TYPE1 unk_10A3B[0x1];
     /* 0x10A3C */ UNK_TYPE1 unk_10A3C[0x2C];
     /* 0x10A68 */ u8 unk_10A68;
@@ -262,7 +257,7 @@ typedef struct CommonData {
     /* 0x10A6C */ UNK_TYPE1 unk_10A6C[0x14];
     /* 0x10A80 */ UNK_TYPE1 unk_10A80[0x2];
     /* 0x10A82 */ s16 unk_10A82;
-    /* 0x10A84 */ u8 unk10A84[0x2C];
+    /* 0x10A84 */ u8 unk_10A84[0x2C];
     /* 0x10AB0 */ u8 unk_10AB0; // named "pad_connected" in AC GCN decomp
     /* 0x10AB1 */ UNK_TYPE1 unk_10AB1[0x7];
 } CommonData; // size = 0x10AB8

--- a/include/m_common_data.h
+++ b/include/m_common_data.h
@@ -168,11 +168,11 @@ typedef struct CommonData {
     /* 0x02F60 */ LandInfo landInfo; // town name & id
     /* 0x02F6A */ u8 unk_02F6A[0x61E];
     /* 0x03588 */ mHm_hs_c homes[PLAYER_NUM];
-    /* 0x062A8 */ mFM_fg_c fg[FG_BLOCK_Z_NUM][FG_BLOCK_X_NUM]; // fg items (fg = foreground?)
+    /* 0x062A8 */ Foreground foreground[FG_BLOCK_Z_NUM][FG_BLOCK_X_NUM];
     /* 0x09EA8 */ u8 unk_09EA8[0x70];
     /* 0x09F18 */ Animal_c animals[ANIMAL_NUM_MAX]; // villagers in town
     /* 0x0EC70 */ u8 unk_0EC70[0x134];
-    /* 0x0EDA4 */ mEv_event_save_c event_save_data;
+    /* 0x0EDA4 */ EventSaveInfo eventSaveInfo;
     /* 0x0EE40 */ u8 unk_0EE40[0x118];
     /* 0x0EF58 */ u16 fruit;
     /* 0x0EF5A */ UNK_TYPE1 unk_0EF5A[0x12];

--- a/include/m_event.h
+++ b/include/m_event.h
@@ -4,9 +4,9 @@
 #include "ultra64.h"
 #include "unk.h"
 
-typedef struct mEv_event_save_c {
+typedef struct EventSaveInfo {
     /* 0x00 */ char unk00[0x9C];
-} mEv_event_save_c; // size >= 0x9C
+} EventSaveInfo; // size >= 0x9C
 
 typedef struct Event {
     /* 0x00 */ u8 unk_00;
@@ -21,7 +21,7 @@ typedef struct Event {
 
 // void func_8007D140_jp();
 // void func_8007D180_jp();
-void mEv_ClearEventSaveInfo(mEv_event_save_c* event_save);
+void mEv_ClearEventSaveInfo(EventSaveInfo* eventSaveInfo);
 void mEv_ClearEventInfo(void);
 // void func_8007D25C_jp();
 // void func_8007D2B8_jp();

--- a/include/m_field_info.h
+++ b/include/m_field_info.h
@@ -15,7 +15,7 @@ typedef enum FieldType {
   /* 4 */ FI_FIELDTYPE_NPC_ROOM,
   /* 5 */ FI_FIELDTYPE_DEMO,
   /* 6 */ FI_FIELDTYPE_PLAYER_ROOM,
-  /* 7 */ FI_FIELDTYPE_NUM,
+  /* 7 */ FI_FIELDTYPE_NUM
 } FieldType;
 
 
@@ -25,7 +25,7 @@ typedef enum FieldRoom {
   /* 0x6000 */ FI_FIELD_PLAYER0_ROOM = FI_TO_FIELD_ID(FI_FIELDTYPE_PLAYER_ROOM, 0),
   /* 0x6001 */ FI_FIELD_PLAYER1_ROOM,
   /* 0x6002 */ FI_FIELD_PLAYER2_ROOM,
-  /* 0x6003 */ FI_FIELD_PLAYER3_ROOM,
+  /* 0x6003 */ FI_FIELD_PLAYER3_ROOM
 } FieldRoom;
 
 

--- a/include/m_field_make.h
+++ b/include/m_field_make.h
@@ -18,9 +18,9 @@ struct Game;
 #define UT_Z_NUM UT_BASE_NUM /* Spaces per block (acre) in z direction */
 #define UT_TOTAL_NUM (UT_X_NUM * UT_Z_NUM)
 
-typedef struct mFM_fg_c {
+typedef struct Foreground {
   /* 0x000 */ u16 items[UT_Z_NUM][UT_X_NUM];
-} mFM_fg_c; // size = 0x200
+} Foreground; // size = 0x200
 
 // void func_80084ED0_jp();
 // void func_80084FAC_jp();

--- a/include/m_land.h
+++ b/include/m_land.h
@@ -7,8 +7,8 @@
 #define LAND_NAME_SIZE 6
 #define LAND_NAME_MURA_SIZE (LAND_NAME_SIZE + 2)
 
-typedef struct mLd_land_info_c {
+typedef struct LandInfo {
     char unk00[0xA];
-} mLd_land_info_c; // size >= 0xA
+} LandInfo; // size >= 0xA
 
 #endif

--- a/include/m_private.h
+++ b/include/m_private.h
@@ -50,7 +50,7 @@ typedef struct PrivateInventory {
     /* 0x28 */ u32 loan;
 } PrivateInventory; // size = 0x2C
 
-typedef struct Private_c {
+typedef struct PrivateInfo {
     /* 0x000 */ UNK_TYPE1 unk000[0x10];
     /* 0x010 */ s8 gender;
     /* 0x011 */ UNK_TYPE1 unk011[0x3];
@@ -67,6 +67,6 @@ typedef struct Private_c {
     /* 0xA90 */ UNK_TYPE1 unkA8F[0xF8];
     /* 0xB88 */ mPr_map_info_c maps[mPr_FOREIGN_MAP_COUNT]; /* maps 'collected' for foreign towns */
     /* 0xBC8 */ UNK_TYPE1 unkBC8[0x8];
-} Private_c; // size = 0xBD0
+} PrivateInfo; // size = 0xBD0
 
 #endif

--- a/include/m_submenu.h
+++ b/include/m_submenu.h
@@ -63,7 +63,7 @@ typedef enum SubmenuProgramId {
     /* 18 */ SUBMENU_PROGRAM_18,
     /* 19 */ SUBMENU_PROGRAM_19,
     /* 20 */ SUBMENU_PROGRAM_CATALOG,
-    /* 21 */ SUBMENU_PROGRAM_MAX,
+    /* 21 */ SUBMENU_PROGRAM_MAX
 } SubmenuProgramId;
 
 typedef void (*SubmenuMoveFunc)(struct Submenu*);

--- a/src/code/m_cockroach.c
+++ b/src/code/m_cockroach.c
@@ -102,7 +102,7 @@ s32 mCkRh_PlussGokiN_NowRoom(s32 count) {
     s32 pad[1] UNUSED;
 
     if (FI_IS_PLAYER_ROOM(fieldId)) {
-        player = common_data.player_no;
+        player = common_data.playerNumber;
         housefieldId = FI_GET_PLAYER_ROOM_NO(fieldId);
         homeId = mHS_get_arrange_idx(player) & 3;
         if ((player < PLAYER_NUM) && (housefieldId == homeId)) {
@@ -124,7 +124,7 @@ s32 mCkRh_MinusGokiN_NowRoom(s32 count) {
     s32 pad[1] UNUSED;
 
     if (FI_IS_PLAYER_ROOM(fieldId)) {
-        player = common_data.player_no;
+        player = common_data.playerNumber;
         housefieldId = FI_GET_PLAYER_ROOM_NO(fieldId);
         homeId = mHS_get_arrange_idx(player) & 3;
         if ((player < PLAYER_NUM) && (housefieldId == homeId)) {

--- a/src/code/m_start_data_init.c
+++ b/src/code/m_start_data_init.c
@@ -41,7 +41,7 @@
 #include "m_flashrom.h"
 
 void famicom_emu_initial_common_data(void) {
-    FamicomEmuCommonData* famicom = &common_data.famicom_emu_common_data;
+    FamicomEmuCommonData* famicom = &common_data.famicomEmuCommonData;
 
     famicom->unk00 = 0;
     famicom->unk02 = 0x3E8;
@@ -187,20 +187,20 @@ void mSDI_PullTreeUnderPlayerBlock(void) {
 
 s32 mSDI_StartInitNew(Game* game2, s32 player_no, s32 malloc_flag) {
     Game_Play* game_play = (Game_Play*)game2;
-    Private_c* priv;
-    Private_c* priv_p;
+    PrivateInfo* priv;
+    PrivateInfo* priv_p;
     Game* game = NULL;
     s32 i;
     UNUSED s32 pad[2];
 
-    common_data.scene_from_title_demo = SCENE_START_DEMO;
+    common_data.sceneFromTitleDemo = SCENE_START_DEMO;
     lbRTC_GetTime(&common_data.time.rtcTime);
 
-    priv = &common_data.private[player_no];
-    common_data.now_private = priv;
-    common_data.player_no = player_no;
+    priv = &common_data.saveFilePrivateInfo[player_no];
+    common_data.privateInfo = priv;
+    common_data.playerNumber = player_no;
 
-    common_data.now_private->gender = mPr_SEX_MALE;
+    common_data.privateInfo->gender = mPr_SEX_MALE;
 
     decide_fruit(&common_data.fruit);
     if (malloc_flag == 0) {
@@ -215,7 +215,7 @@ s32 mSDI_StartInitNew(Game* game2, s32 player_no, s32 malloc_flag) {
     mFM_SetBlockKindLoadCombi(game);
     mAGrw_ChangeTree2FruitTree();
 
-    priv_p = &common_data.private[0];
+    priv_p = &common_data.saveFilePrivateInfo[0];
 
     mMld_SetDefaultMelody();
     mLd_LandDataInit();
@@ -248,13 +248,13 @@ s32 mSDI_StartInitNew(Game* game2, s32 player_no, s32 malloc_flag) {
         common_data.homes[i].unk_024 = i;
     }
 
-    common_data.station_type = RANDOM_F(15);
+    common_data.stationType = RANDOM_F(15);
 
     for (i = 0; i < PLAYER_NUM; i++) {
-        mPr_ClearMotherMailInfo(&common_data.mother_mail[i]);
+        mPr_ClearMotherMailInfo(&common_data.motherMailInfo[i]);
     }
 
-    mPr_SetPossessionItem(common_data.now_private, 0, ITM_MONEY_1000, mPr_ITEM_COND_QUEST);
+    mPr_SetPossessionItem(common_data.privateInfo, 0, ITM_MONEY_1000, mPr_ITEM_COND_QUEST);
     mCkRh_InitGokiSaveData_InitNewPlayer();
     mEv_2nd_init(&game_play->event);
     famicom_emu_initial_common_data();
@@ -263,7 +263,7 @@ s32 mSDI_StartInitNew(Game* game2, s32 player_no, s32 malloc_flag) {
 
 s32 mSDI_StartInitFrom(Game* game2, s32 player_no, s32 malloc_flag) {
     Game_Play* game_play = (Game_Play*)game2;
-    Private_c* priv;
+    PrivateInfo* priv;
     Game* game = game2;
     s32 res = FALSE;
 
@@ -271,15 +271,15 @@ s32 mSDI_StartInitFrom(Game* game2, s32 player_no, s32 malloc_flag) {
         game = NULL;
     }
 
-    common_data.scene_from_title_demo = SCENE_FG;
+    common_data.sceneFromTitleDemo = SCENE_FG;
     lbRTC_GetTime(&common_data.time.rtcTime);
 
     if (mFRm_CheckSaveData() == TRUE) {
-        priv = &common_data.private[player_no];
+        priv = &common_data.saveFilePrivateInfo[player_no];
         if (mPr_CheckPrivate(priv) == TRUE) {
             if (priv->exists == TRUE) {
-                common_data.now_private = priv;
-                common_data.player_no = player_no;
+                common_data.privateInfo = priv;
+                common_data.playerNumber = player_no;
                 mFM_SetBlockKindLoadCombi(game);
                 mEv_init_force(&game_play->event);
                 mHsRm_GetHuusuiRoom(game, player_no);
@@ -291,8 +291,8 @@ s32 mSDI_StartInitFrom(Game* game2, s32 player_no, s32 malloc_flag) {
             } else {
                 common_data.player_decoy_flag = TRUE;
                 priv->exists = TRUE;
-                common_data.now_private = priv;
-                common_data.player_no = player_no;
+                common_data.privateInfo = priv;
+                common_data.playerNumber = player_no;
                 mFM_SetBlockKindLoadCombi(game);
                 mHsRm_GetHuusuiRoom(game, player_no);
                 mSP_ExchangeLineUp_InGame(game);
@@ -316,21 +316,21 @@ s32 mSDI_StartInitFrom(Game* game2, s32 player_no, s32 malloc_flag) {
 
 s32 mSDI_StartInitNewPlayer(Game* game, s32 player_no, s32 malloc_flag) {
     Game_Play* game_play = (Game_Play*)game;
-    Private_c* priv;
+    PrivateInfo* priv;
     s32 res = FALSE;
     UNUSED s32 pad;
 
-    common_data.scene_from_title_demo = SCENE_START_DEMO2;
+    common_data.sceneFromTitleDemo = SCENE_START_DEMO2;
     lbRTC_GetTime(&common_data.time.rtcTime);
 
-    priv = &common_data.private[player_no];
+    priv = &common_data.saveFilePrivateInfo[player_no];
     if (mFRm_CheckSaveData() == TRUE) {
         if (mPr_CheckPrivate(priv) != TRUE) {
             mPr_InitPrivateInfo(priv);
-            common_data.now_private = priv;
-            mPr_SetPossessionItem(common_data.now_private, 0, ITM_MONEY_1000, mPr_ITEM_COND_QUEST);
-            common_data.player_no = player_no;
-            common_data.now_private->gender = mPr_SEX_MALE;
+            common_data.privateInfo = priv;
+            mPr_SetPossessionItem(common_data.privateInfo, 0, ITM_MONEY_1000, mPr_ITEM_COND_QUEST);
+            common_data.playerNumber = player_no;
+            common_data.privateInfo->gender = mPr_SEX_MALE;
             if (malloc_flag == 0) {
                 mFM_SetBlockKindLoadCombi(game);
                 mEv_init_force(&game_play->event);
@@ -360,7 +360,7 @@ s32 mSDI_StartInitPak(Game* game2, s32 player_no, s32 malloc_flag) {
     }
 
     if (player_no < 5) {
-        common_data.scene_from_title_demo = SCENE_FG;
+        common_data.sceneFromTitleDemo = SCENE_FG;
     }
 
     if (mFRm_CheckSaveData() == TRUE) {
@@ -389,8 +389,8 @@ s32 mSDI_StartInitErr(UNUSED Game* game, UNUSED s32 player_no, UNUSED s32 malloc
 void mSDI_StartInitAfter(Game* game, s32 renewal_reserve_flag, s32 malloc_flag) {
     Game_Play* game_play = (Game_Play*)game;
 
-    common_data.house_owner_name = -1;
-    common_data.last_field_id = -1;
+    common_data.houseOwnerName = -1;
+    common_data.lastFieldId = -1;
 
     mHm_SetNowHome();
     mNpc_RenewalAnimalMemory();
@@ -416,17 +416,17 @@ void mSDI_StartInitAfter(Game* game, s32 renewal_reserve_flag, s32 malloc_flag) 
     mHm_CheckRehouseOrder();
     decide_fish_location(&common_data.fish_location);
     mTRC_init(game_play);
-    common_data.goki_shocked_flag = FALSE;
+    common_data.gokiShockedFlag = FALSE;
     func_800A6548_jp();
     func_800B9B2C_jp();
     func_800A91DC_jp();
-    mPr_SendForeingerAnimalMail(common_data.now_private);
+    mPr_SendForeingerAnimalMail(common_data.privateInfo);
     mPr_StartSetCompleteTalkInfo();
     mMsm_SendInformationMail();
     func_8008DCF8_jp();
     func_800A4D10_jp();
     mSN_decide_msg();
-    mPr_RenewalMapInfo(common_data.now_private->maps, mPr_FOREIGN_MAP_COUNT, &common_data.land_info);
+    mPr_RenewalMapInfo(common_data.privateInfo->maps, mPr_FOREIGN_MAP_COUNT, &common_data.landInfo);
 }
 
 typedef s32 (*mSDI_INIT_PROC)(Game*, s32, s32);

--- a/src/code/m_start_data_init.c
+++ b/src/code/m_start_data_init.c
@@ -113,7 +113,7 @@ void mSDI_ClearMoneyPlayerHomeStationBlock(void) {
         block_x = block_num[i][0];
 
         depositOffset = block_num[i][1] * FG_BLOCK_X_NUM + block_x;
-        items = common_data.fg[block_z][block_x].items[0];
+        items = common_data.foreground[block_z][block_x].items[0];
 
         if (items != NULL) {
             for (ut_z = 0; ut_z < UT_Z_NUM; ut_z++) {
@@ -154,12 +154,12 @@ void mSDI_PullTreeBlock(u16* items_p, s32 ut) {
 }
 
 void mSDI_PullTree(void) {
-    mFM_fg_c* fg_block;
+    Foreground* fg_block;
     s32 block_z;
 
     for (block_z = 0; block_z < FG_BLOCK_Z_NUM; block_z++) {
         /* Clear trees against the cliffs on the left and right town cliff borders */
-        fg_block = &common_data.fg[block_z][0];
+        fg_block = &common_data.foreground[block_z][0];
         mSDI_PullTreeBlock(fg_block->items[0], 0);
         mSDI_PullTreeBlock((fg_block + FG_BLOCK_X_NUM - 1)->items[0], UT_X_NUM - 1);
     }
@@ -177,7 +177,7 @@ void mSDI_PullTreeUnderPlayerBlock(void) {
      * ...
      **/
 
-    u16* items = &common_data.fg[2][2].items[0][0];
+    u16* items = &common_data.foreground[2][2].items[0][0];
 
     mSDI_PullTreeUT(&items[7]);
     mSDI_PullTreeUT(&items[8]);
@@ -219,7 +219,7 @@ s32 mSDI_StartInitNew(Game* game2, s32 player_no, s32 malloc_flag) {
 
     mMld_SetDefaultMelody();
     mLd_LandDataInit();
-    mEv_ClearEventSaveInfo(&common_data.event_save_data);
+    mEv_ClearEventSaveInfo(&common_data.eventSaveInfo);
     mEv_init(&game_play->event);
     mNpc_InitNpcAllInfo(malloc_flag);
 

--- a/src/code/m_submenu.c
+++ b/src/code/m_submenu.c
@@ -471,7 +471,7 @@ void mSM_move_LINKWait(Submenu* submenu) {
 
     if (submenu->unk_00 != 4) {
         if (((submenu->programId == SUBMENU_PROGRAM_LEDIT) && (submenu->unk_10 == 0)) ||
-            (common_data.now_private->gender == 0)) {
+            (common_data.privateInfo->gender == 0)) {
             sAdo_SpecChange(5);
         } else {
             sAdo_SpecChange(6);
@@ -551,11 +551,11 @@ void mSM_submenu_draw(Submenu* submenu, struct Game_Play* game_play) {
 }
 
 s32 mSM_check_item_for_furniture(s32 index, UNUSED s32 arg1) {
-    u16 temp_v0 = common_data.now_private->inventory.pockets[index];
+    u16 temp_v0 = common_data.privateInfo->inventory.pockets[index];
 
     if (((temp_v0 & 0xF000) >> 0xC) == 2) {
         if ((((temp_v0 & 0xF00) >> 8) != 3) && (((temp_v0 & 0xF00) >> 8) != 0xF) && (((temp_v0 & 0xF00) >> 8) != 0xD)) {
-            if (!((common_data.now_private->inventory.item_conditions >> (index << 1)) & 3)) {
+            if (!((common_data.privateInfo->inventory.item_conditions >> (index << 1)) & 3)) {
                 if (temp_v0 != 0) {
                     return true;
                 }
@@ -566,8 +566,8 @@ s32 mSM_check_item_for_furniture(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_sell(s32 index, UNUSED s32 arg1) {
-    u16 temp_v0 = common_data.now_private->inventory.pockets[index];
-    Private_c* private = common_data.now_private;
+    u16 temp_v0 = common_data.privateInfo->inventory.pockets[index];
+    PrivateInfo* private = common_data.privateInfo;
 
     if (!((private->inventory.item_conditions >> (index << 1)) & 3)) {
         if (temp_v0 != 0) {
@@ -580,7 +580,7 @@ s32 mSM_check_item_for_sell(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_give(s32 index, UNUSED s32 arg1) {
-    Private_c* private = common_data.now_private;
+    PrivateInfo* private = common_data.privateInfo;
 
     if (!((private->inventory.item_conditions >> (index << 1)) & 3)) {
         if (private->inventory.pockets[index] != 0) {
@@ -591,8 +591,8 @@ s32 mSM_check_item_for_give(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_take(s32 index, s32 arg1) {
-    u16 temp_v0 = common_data.now_private->inventory.pockets[index];
-    Private_c* private = common_data.now_private;
+    u16 temp_v0 = common_data.privateInfo->inventory.pockets[index];
+    PrivateInfo* private = common_data.privateInfo;
 
     if (temp_v0 != 0) {
         if (!((private->inventory.item_conditions >> (index << 1)) & 3)) {
@@ -607,8 +607,8 @@ s32 mSM_check_item_for_take(s32 index, s32 arg1) {
 }
 
 s32 mSM_check_item_for_minidisk(s32 index, UNUSED s32 arg1) {
-    u16 temp_v0 = common_data.now_private->inventory.pockets[index];
-    Private_c* private = common_data.now_private;
+    u16 temp_v0 = common_data.privateInfo->inventory.pockets[index];
+    PrivateInfo* private = common_data.privateInfo;
 
     if (((temp_v0 & 0xF000) >> 0xC) == 2) {
         if (!((private->inventory.item_conditions >> (index << 1)) & 3)) {
@@ -621,7 +621,7 @@ s32 mSM_check_item_for_minidisk(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_shrine(s32 index, UNUSED s32 arg1) {
-    if (((common_data.now_private->inventory.item_conditions >> (index * 2)) & 3) == 2) {
+    if (((common_data.privateInfo->inventory.item_conditions >> (index * 2)) & 3) == 2) {
         if (mQst_CheckLimitbyPossessionIdx(index) != 0) {
             return true;
         }
@@ -631,8 +631,8 @@ s32 mSM_check_item_for_shrine(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_entrust(s32 index, UNUSED s32 arg1) {
-    u16 temp_v0 = common_data.now_private->inventory.pockets[index];
-    Private_c* temp_v1 = common_data.now_private;
+    u16 temp_v0 = common_data.privateInfo->inventory.pockets[index];
+    PrivateInfo* temp_v1 = common_data.privateInfo;
 
     if ((temp_v0 == 0) || (!((temp_v1->inventory.item_conditions >> (index << 1)) & 3) &&
                            ((((temp_v0 & 0xF000) >> 0xC) != 2) || (((temp_v0 & 0xF00) >> 8) != 1)))) {
@@ -643,7 +643,7 @@ s32 mSM_check_item_for_entrust(s32 index, UNUSED s32 arg1) {
 }
 
 s32 mSM_check_item_for_exchange(s32 index, s32 arg1) {
-    Private_c* temp_v0 = common_data.now_private;
+    PrivateInfo* temp_v0 = common_data.privateInfo;
     u16 temp_v1 = temp_v0->inventory.pockets[index];
     UNUSED s32 pad;
 

--- a/src/overlays/gamestates/ovl_play/m_play.c
+++ b/src/overlays/gamestates/ovl_play/m_play.c
@@ -102,7 +102,7 @@ static u16 S_back_title_timer;
 static u16 S_se_endcheck_timeout;
 
 void Game_play_Reset_destiny(void) {
-    Private_Sub_A86* temp = &common_data.now_private->unk_A86;
+    Private_Sub_A86* temp = &common_data.privateInfo->unk_A86;
     u8* day = &common_data.time.rtcTime.day;
     u8* month = &common_data.time.rtcTime.month;
 
@@ -272,8 +272,8 @@ void Game_play_fbdemo_wipe_move(Game_Play* game_play) {
 
                 case 8:
                     if (common_data.unk_100E4 != NULL) {
-                        if (*common_data.unk_100E4 != NULL) {
-                            (*common_data.unk_100E4)(game_play);
+                        if (common_data.unk_100E4->unk_00 != NULL) {
+                            common_data.unk_100E4->unk_00(game_play);
                             Game_play_change_scene_move_end(game_play);
                         }
                     }
@@ -363,7 +363,7 @@ void play_cleanup(Game* game) {
     game_play->unk_1DAC = -1;
     mSM_submenu_ovlptr_cleanup(&game_play->submenu);
     mPlib_Object_Exchange_keep_Player_dt(game_play);
-    mHsRm_GetHuusuiRoom(0, common_data.player_no);
+    mHsRm_GetHuusuiRoom(0, common_data.playerNumber);
     func_80087280_jp();
     zelda_CleanupArena();
 }


### PR DESCRIPTION
common_data affects a lot of files so I'm separating it into its own pr, and I can clean up other stuff like m_start_data_init in a different pr.

- Renamed structs and struct members to match the style guide
- Made all the unk names in common data uniformly unk_000 format
- Removed the last comma on some enums because those show up as errors on decomp.me
- Ran the format script, which should fix the pointer symbol attaching to the name instead of the type
- fixed the `CommonData_100E4_Func` thing, this was "animal_logo_clip" in the GC repo, so I made it a struct with callback function pointers like the other clip structs