### PR TITLE
Update `OPEN_DISPS`/`CLOSE_DISPS` macros, clean up various fake matches, and match `mSM_draw_mail`

### DIFF
--- a/include/gfx.h
+++ b/include/gfx.h
@@ -46,15 +46,17 @@ typedef struct GraphicsContext {
 // __gfxCtx shouldn't be used directly.
 // Use the DISP macros defined above when writing to display buffers.
 #define OPEN_DISPS(gfxCtx)                  \
+    do {} while (0);                        \
     {                                       \
         GraphicsContext* __gfxCtx = gfxCtx; \
         s32 __dispPad UNUSED;               \
         do {} while (0)
 
 #define CLOSE_DISPS(gfxCtx) \
-    (void)0;                \
+        do {} while (0);    \
+        (void)0;            \
     }                       \
-    (void)0
+    do {} while (0)
 
 #define qs1616(e) ((s32)((e)*0x00010000))
 

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -108,9 +108,6 @@ void game_debug_draw_last(Game* game, GraphicsContext* gfxCtx) {
         gfxclose(gfxHead, gfx);
         POLY_OPA_DISP = gfx;
 
-        do {
-        } while (0);
-
         CLOSE_DISPS(gfxCtx);
     }
 

--- a/src/code/m_actor.c
+++ b/src/code/m_actor.c
@@ -254,12 +254,6 @@ void Actor_draw(Game_Play* game_play, Actor* actor) {
 
     fault_AddClient(&faultClient, func_80056380_jp, actor, "Actor_draw");
 
-    //! FAKE
-    if (1) {}
-    if (1) {}
-    if (1) {}
-    if (1) {}
-
     OPEN_DISPS(game_play->state.gfxCtx);
 
     light = Global_light_read(&game_play->glight, game_play->state.gfxCtx);

--- a/src/code/m_actor_shadow.c
+++ b/src/code/m_actor_shadow.c
@@ -192,19 +192,6 @@ void mActorShadow_GetLastAlphaScale(f32* scale, u8* alpha, Actor* actor, ShadowI
     *alpha = alphaCalc;
 }
 
-#define AC_GCN_OPEN_DISP(gfxCtx)            \
-    {                                       \
-        GraphicsContext* __gfxCtx = gfxCtx; \
-        int __gfx_opened = 0;               \
-        do {                                \
-        } while (0)
-
-#define AC_GCN_CLOSE_DISP(gfxCtx) \
-    (void)__gfx_opened;           \
-    }                             \
-    do {                          \
-    } while (0)
-
 void mActorShadow_DrawActorShadow(Actor* actor, ShadowInfo* shadow, Game* game, f32 rad, s32 id, xyz_t ofs) {
     Game_Play* play = (Game_Play*)game;
     u8 alpha;
@@ -217,7 +204,7 @@ void mActorShadow_DrawActorShadow(Actor* actor, ShadowInfo* shadow, Game* game, 
 
     mActorShadow_GetLastAlphaScale(&scale, &alpha, actor, shadow);
 
-    AC_GCN_OPEN_DISP(play->state.gfxCtx);
+    OPEN_DISPS(play->state.gfxCtx);
 
     _texture_z_light_fog_prim_shadow(play->state.gfxCtx);
 
@@ -287,7 +274,7 @@ void mActorShadow_DrawActorShadow(Actor* actor, ShadowInfo* shadow, Game* game, 
         gSPDisplayList(SHADOW_DISP++, ef_shadow_in_modelT);
     }
 
-    AC_GCN_CLOSE_DISP(play->state.gfxCtx);
+    CLOSE_DISPS(play->state.gfxCtx);
 }
 
 void mActorShadow_GetShadowPosition(Actor* actor, xyz_t* position) {

--- a/src/code/m_lib.c
+++ b/src/code/m_lib.c
@@ -594,9 +594,6 @@ void none_proc2(Actor* actor UNUSED, Game_Play* play UNUSED) {
 }
 
 void Cheap_gfx_display(Game_Play* play, Gfx* dl) {
-    //! FAKE
-    if (1) {}
-
     OPEN_DISPS(play->state.gfxCtx);
 
     _texture_z_light_fog_prim(play->state.gfxCtx);
@@ -609,9 +606,6 @@ void Cheap_gfx_display(Game_Play* play, Gfx* dl) {
 }
 
 void Cheap_gfx_display_xlu(Game_Play* play, Gfx* dl) {
-    //! FAKE
-    if (1) {}
-
     OPEN_DISPS(play->state.gfxCtx);
 
     _texture_z_light_fog_prim_xlu(play->state.gfxCtx);

--- a/src/code/m_rcp.c
+++ b/src/code/m_rcp.c
@@ -458,8 +458,6 @@ Gfx* two_tex_scroll(GraphicsContext* gfxCtx, s32 tile1, u32 x1, u32 y1, s32 widt
 }
 
 void DisplayList_initialize(GraphicsContext* gfxCtx, u8 clearR, u8 clearG, u8 clearB, Game_Play* game_play) {
-    void* unk_008;
-
     OPEN_DISPS(gfxCtx);
 
     gSPDisplayList(POLY_OPA_DISP++, RSP_RDP_clear_data);
@@ -483,14 +481,16 @@ void DisplayList_initialize(GraphicsContext* gfxCtx, u8 clearR, u8 clearG, u8 cl
     gDPSetColorImage(SHADOW_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
     gDPSetColorImage(LIGHT_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
 
-    unk_008 = gfxCtx->unk_008;
+    {
+        void* unk_008 = gfxCtx->unk_008;
 
-    gDPSetDepthImage(POLY_OPA_DISP++, unk_008);
-    gDPSetDepthImage(POLY_XLU_DISP++, unk_008);
-    gDPSetDepthImage(OVERLAY_DISP++, unk_008);
-    gDPSetDepthImage(UNK_2B0_DISP++, unk_008);
-    gDPSetDepthImage(SHADOW_DISP++, unk_008);
-    gDPSetDepthImage(LIGHT_DISP++, unk_008);
+        gDPSetDepthImage(POLY_OPA_DISP++, unk_008);
+        gDPSetDepthImage(POLY_XLU_DISP++, unk_008);
+        gDPSetDepthImage(OVERLAY_DISP++, unk_008);
+        gDPSetDepthImage(UNK_2B0_DISP++, unk_008);
+        gDPSetDepthImage(SHADOW_DISP++, unk_008);
+        gDPSetDepthImage(LIGHT_DISP++, unk_008);
+    }
 
     if ((game_play == NULL) || ((game_play->submenu.unk_00 < 2) && (fbdemo_mode < 2))) {
         gDPSetColorImage(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_008);
@@ -507,9 +507,6 @@ void DisplayList_initialize(GraphicsContext* gfxCtx, u8 clearR, u8 clearG, u8 cl
         gDPFillRectangle(POLY_OPA_DISP++, 0, 0, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1);
         gDPPipeSync(POLY_OPA_DISP++);
     }
-
-    //! FAKE:
-    if (gfxCtx && gfxCtx && gfxCtx) {}
 
     CLOSE_DISPS(gfxCtx);
 

--- a/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
+++ b/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
@@ -147,7 +147,6 @@ void aKOI_actor_draw(Actor* thisx, Game_Play* game_play) {
         gSPSegment(__polyOpa++, 0x06, object);
         CLOSE_POLY_OPA_DISPS();
         CLOSE_DISPS(gfxCtx);
-        if (1) {}
         cKF_Si3_draw_R_SV(game_play, &this->skeletonInfo, mtx, NULL, NULL, this);
         common_data.unk_10080->unk_04(game_play, &aKOI_shadow_data, 0x27);
     }

--- a/src/overlays/actors/ovl_Sample/ac_sample.c
+++ b/src/overlays/actors/ovl_Sample/ac_sample.c
@@ -152,19 +152,6 @@ void Ac_Sample_Actor_ct(Actor* thisx, Game_Play* play) {
     this->segment = play->objectExchangeBank.status[thisx->unk_026].segment;
 }
 
-#define AC_GCN_OPEN_DISP(gfxCtx)            \
-    {                                       \
-        GraphicsContext* __gfxCtx = gfxCtx; \
-        int __gfx_opened = 0;               \
-        do {                                \
-        } while (0)
-
-#define AC_GCN_CLOSE_DISP(gfxCtx) \
-    (void)__gfx_opened;           \
-    }                             \
-    do {                          \
-    } while (0)
-
 #define OPEN_CUSTOM_POLY_OPA()                \
     {                                         \
         Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
@@ -188,7 +175,7 @@ void Ac_Sample_Actor_draw_normal(Sample* this, Game_Play* play) {
 
         _texture_z_light_fog_prim(play->state.gfxCtx);
 
-        AC_GCN_OPEN_DISP(play->state.gfxCtx);
+        OPEN_DISPS(play->state.gfxCtx);
         OPEN_CUSTOM_POLY_OPA();
         gDPLoadTextureBlockS(__polyOpa++, hnw_tmem_txt, G_IM_FMT_I, G_IM_SIZ_8b, 64, 64, 0, G_TX_MIRROR | G_TX_WRAP,
                              G_TX_MIRROR | G_TX_WRAP, 7, 7, G_TX_NOLOD, G_TX_NOLOD);
@@ -198,7 +185,7 @@ void Ac_Sample_Actor_draw_normal(Sample* this, Game_Play* play) {
 
         CLOSE_CUSTOM_POLY_OPA();
 
-        AC_GCN_CLOSE_DISP(play->state.gfxCtx);
+        CLOSE_DISPS(play->state.gfxCtx);
 
         cKF_Si3_draw_R_SV(play, info, mtx, NULL, NULL, NULL);
     }

--- a/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
+++ b/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
@@ -132,19 +132,6 @@ void aTKT_actor_move(Actor* thisx, Game_Play* game_play) {
     this->process(this);
 }
 
-#define AC_GCN_OPEN_DISP(gfxCtx)            \
-    {                                       \
-        GraphicsContext* __gfxCtx = gfxCtx; \
-        int __gfx_opened = 0;               \
-        do {                                \
-        } while (0)
-
-#define AC_GCN_CLOSE_DISP(gfxCtx) \
-    (void)__gfx_opened;           \
-    }                             \
-    do {                          \
-    } while (0)
-
 #define OPEN_POLY_OPA_DISPS()                 \
     {                                         \
         Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
@@ -183,17 +170,15 @@ void aTKT_actor_draw(Actor* thisx, Game_Play* game_play) {
 
         _texture_z_light_fog_prim_npc(gfxCtx);
 
-        if (1) {}
-        AC_GCN_OPEN_DISP(gfxCtx);
+        OPEN_DISPS(gfxCtx);
         OPEN_POLY_OPA_DISPS();
-        if (1) {}
 
         Matrix_scale(this->toolActor.actor.scale.x, this->toolActor.actor.scale.y, this->toolActor.actor.scale.z,
                      MTXMODE_APPLY);
         gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
         CLOSE_POLY_OPA_DISPS();
-        AC_GCN_CLOSE_DISP(gfxCtx);
+        CLOSE_DISPS(gfxCtx);
 
         cKF_Si3_draw_R_SV(game_play, skeletonInfo, mtx, NULL, NULL, NULL);
     }

--- a/src/overlays/actors/ovl_Train_Window/ac_train_window.c
+++ b/src/overlays/actors/ovl_Train_Window/ac_train_window.c
@@ -300,7 +300,6 @@ void Train_Window_Actor_draw(Actor* thisx, Game_Play* play) {
     Train_Window* this = (Train_Window*)thisx;
     UNUSED s32 pad;
 
-    if (1) {}
     OPEN_DISPS(play->state.gfxCtx);
     Matrix_translate(0.0f, 0.0f, 0.0f, FALSE);
     Matrix_scale(0.05f, 0.05f, 0.05f, TRUE);

--- a/src/overlays/actors/ovl_Train_Window/ac_train_window.c
+++ b/src/overlays/actors/ovl_Train_Window/ac_train_window.c
@@ -170,19 +170,18 @@ s32 aTrainWindow_DrawGoneOutTunnel(Actor* thisx, Game* game) {
 
     if ((ssc == NULL) || (tsc == NULL)) {
         return 0;
-    } else {
-        OPEN_DISPS(*graph);
-        if (!this->paletteId) {}
-        gSPSegment(POLY_OPA_DISP++, 11, ssc);
-        gSPSegment(POLY_XLU_DISP++, 11, ssc);
-
-        gSPSegment(POLY_OPA_DISP++, 12, tsc);
-        gSPSegment(POLY_XLU_DISP++, 12, tsc);
-
-        CLOSE_DISPS(*graph);
-
-        return 1;
     }
+
+    OPEN_DISPS(*graph);
+
+    gSPSegment(POLY_OPA_DISP++, 11, ssc);
+    gSPSegment(POLY_XLU_DISP++, 11, ssc);
+    gSPSegment(POLY_OPA_DISP++, 12, tsc);
+    gSPSegment(POLY_XLU_DISP++, 12, tsc);
+
+    CLOSE_DISPS(*graph);
+
+    return 1;
 }
 
 s32 aTrainWindow_DrawGoingOutTunnel(Actor* thisx, Game* game) {
@@ -198,26 +197,24 @@ s32 aTrainWindow_DrawGoingOutTunnel(Actor* thisx, Game* game) {
 
     if ((ssc == NULL) || (tsc == NULL)) {
         return 0;
-    } else {
-        OPEN_DISPS(*graph);
-        if (!this->paletteId) {}
-        gSPSegment(POLY_OPA_DISP++, 11, ssc);
-        gSPSegment(POLY_XLU_DISP++, 11, ssc);
-        gSPSegment(POLY_OPA_DISP++, 12, tsc);
-        if (1) {
-            gSPSegment(POLY_XLU_DISP++, 12, tsc);
-
-            CLOSE_DISPS(*graph);
-
-            if (((s32)this->singleScrollX == 1000) && ((s32)this->twoScrollX1 == 1000)) {
-                this->drawType = aTrainWindow_DrawGoneOutTunnel;
-                this->paletteId = aTrainWindow_GetTreePalletIdx();
-                this->currentPalette = aTrainWindow_tree_pal_table[this->paletteId];
-            }
-
-            return 1;
-        }
     }
+
+    OPEN_DISPS(*graph);
+
+    gSPSegment(POLY_OPA_DISP++, 11, ssc);
+    gSPSegment(POLY_XLU_DISP++, 11, ssc);
+    gSPSegment(POLY_OPA_DISP++, 12, tsc);
+    gSPSegment(POLY_XLU_DISP++, 12, tsc);
+
+    CLOSE_DISPS(*graph);
+
+    if (((s32)this->singleScrollX == 1000) && ((s32)this->twoScrollX1 == 1000)) {
+        this->drawType = aTrainWindow_DrawGoneOutTunnel;
+        this->paletteId = aTrainWindow_GetTreePalletIdx();
+        this->currentPalette = aTrainWindow_tree_pal_table[this->paletteId];
+    }
+
+    return 1;
 }
 
 s32 aTrainWindow_NoDraw(Actor* thisx, UNUSED Game* game) {
@@ -238,24 +235,23 @@ s32 aTrainWindow_DrawInTunnel(Actor* thisx, Game* game) {
 
     if ((ssc == NULL) || (tsc == NULL)) {
         return 0;
-    } else {
-        OPEN_DISPS(game->gfxCtx);
-        if (!this->paletteId) {}
-        gSPSegment(POLY_OPA_DISP++, 11, ssc);
-        gSPSegment(POLY_XLU_DISP++, 11, ssc);
-
-        gSPSegment(POLY_OPA_DISP++, 12, tsc);
-        gSPSegment(POLY_XLU_DISP++, 12, tsc);
-
-        CLOSE_DISPS(game->gfxCtx);
-
-        if (common_data.sunlightFlag != 0) {
-            this->paletteId = aTrainWindow_GetTreePalletIdx();
-            this->currentPalette = aTrainWindow_tree_pal_table[this->paletteId];
-            this->drawType = aTrainWindow_DrawGoingOutTunnel;
-        }
-        return 1;
     }
+    OPEN_DISPS(game->gfxCtx);
+
+    gSPSegment(POLY_OPA_DISP++, 11, ssc);
+    gSPSegment(POLY_XLU_DISP++, 11, ssc);
+    gSPSegment(POLY_OPA_DISP++, 12, tsc);
+    gSPSegment(POLY_XLU_DISP++, 12, tsc);
+
+    CLOSE_DISPS(game->gfxCtx);
+
+    if (common_data.sunlightFlag != 0) {
+        this->paletteId = aTrainWindow_GetTreePalletIdx();
+        this->currentPalette = aTrainWindow_tree_pal_table[this->paletteId];
+        this->drawType = aTrainWindow_DrawGoingOutTunnel;
+    }
+
+    return 1;
 }
 
 void aTrainWindow_SetLightPrimColorDetail(Game* game, u8 l, u8 polyAlpha, u8 xluAlpha) {
@@ -310,10 +306,8 @@ void Train_Window_Actor_draw(Actor* thisx, Game_Play* play) {
     if (this->drawType(thisx, &play->state) != 0) {
         _texture_z_light_fog_prim(play->state.gfxCtx);
         _texture_z_light_fog_prim_xlu(play->state.gfxCtx);
-        if (1) {}
         aTrainWindow_SetLightPrimColorDetail(&play->state, 127, 255, this->xluAlpha);
         gSPSegment(POLY_XLU_DISP++, 10, this->currentPalette);
-        if (1) {}
         Evw_Anime_Set(&play->state, aTrainWindow_evw_anime_data);
 
         aTrainWindow_SetLightPrimColorDetail(&play->state, 255, 255, this->xluAlpha);

--- a/src/overlays/gamestates/ovl_select/m_select.c
+++ b/src/overlays/gamestates/ovl_select/m_select.c
@@ -895,13 +895,6 @@ void select_draw(Game_Select* select) {
 
     DisplayList_initialize(graph, 0, 0, 0, NULL);
 
-    // FAKE !!
-    if (1) {}
-    if (1) {}
-    if (1) {}
-    if (1) {}
-    if (1) {}
-    if (1) {}
     CLOSE_DISPS(graph);
 
     SET_FULLSCREEN_VIEWPORT(&select->view);

--- a/src/overlays/submenu/submenu_ovl/m_submenu_ovl.c
+++ b/src/overlays/submenu/submenu_ovl/m_submenu_ovl.c
@@ -602,11 +602,23 @@ s32 add_trigger_954[] = { R_CBUTTONS, U_CBUTTONS, L_CBUTTONS, D_CBUTTONS };
 
 f32 move_data_1027[2][4] = { { 2.0f, 0.0f, 300.0f, 1.0f }, { 0.5f, 120.0f, 0.0f, -1.0f } };
 
+#define OPEN_CUSTOM_POLY_OPA()                \
+    {                                         \
+        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
+        int __opa_opened = 0;                 \
+        do {                                  \
+        } while (0)
+
+#define CLOSE_CUSTOM_POLY_OPA()      \
+    __gfxCtx->polyOpa.p = __polyOpa; \
+    (void)__opa_opened;              \
+    }                                \
+    do {                             \
+    } while (0)
+
 void mSM_setup_view(Submenu* submenu, GraphicsContext* gfxCtx, s32 arg1) {
     Mtx* mtx;
-    UNUSED s32 pad;
-    Gfx* gfx;
-    Game_Play1938* view;
+
     if (arg1 != 0) {
         mtx = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
         guOrtho(mtx, SCREEN_WIDTH * -8, SCREEN_WIDTH * 8, SCREEN_HEIGHT * -8, SCREEN_HEIGHT * 8, 1.0f, 2000.0f, 1.0f);
@@ -616,31 +628,31 @@ void mSM_setup_view(Submenu* submenu, GraphicsContext* gfxCtx, s32 arg1) {
     }
 
     OPEN_DISPS(gfxCtx);
+    OPEN_CUSTOM_POLY_OPA();
 
-    gfx = POLY_OPA_DISP;
     if (arg1 == 0) {
+        Game_Play1938* view;
+
         if (submenu->unk_00 != 4) {
             view = &((Game_Play*)gamePT)->unk_1938;
         } else {
             view = &((Game__00743CD0*)gamePT)->unk_00E0;
         }
 
-        gDPPipeSync(gfx++);
-        gDPSetScissor(gfx++, G_SC_NON_INTERLACE, view->viewport.leftX, view->viewport.topY, view->viewport.rightX,
+        gDPPipeSync(__polyOpa++);
+        gDPSetScissor(__polyOpa++, G_SC_NON_INTERLACE, view->viewport.leftX, view->viewport.topY, view->viewport.rightX,
                       view->viewport.bottomY);
-        gSPViewport(gfx++, &view->vp);
-        gDPSetColorImage(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
-        gDPSetScissor(gfx++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+        gSPViewport(__polyOpa++, &view->vp);
+        gDPSetColorImage(__polyOpa++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
+        gDPSetScissor(__polyOpa++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     }
 
     //! FAKE
     if (1) {}
-    if (1) {}
-    if (1) {}
 
-    gSPMatrix(gfx++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    POLY_OPA_DISP = gfx;
+    gSPMatrix(__polyOpa++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 
+    CLOSE_CUSTOM_POLY_OPA();
     CLOSE_DISPS(gfxCtx);
 }
 
@@ -1124,14 +1136,10 @@ void mSM_draw_item(GraphicsContext* gfxCtx, f32 arg1, f32 arg2, f32 arg3, u16 ar
 #pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/submenu/submenu_ovl/m_submenu_ovl/mSM_draw_item.s")
 #endif
 
-#ifdef NON_MATCHING
-// stack issues
 void mSM_draw_mail(GraphicsContext* arg0, f32 arg1, f32 arg2, f32 arg3, struct_func_8085CE18_jp_arg4* arg4, s32 arg5,
                    s32 arg6) {
     struct_8085DCF8* temp_a1;
     s32 var_t0;
-    UNUSED s32 pad;
-    Gfx* gfx;
 
     if (mMl_check_send_mail(arg4) != 0) {
         var_t0 = 2;
@@ -1150,44 +1158,37 @@ void mSM_draw_mail(GraphicsContext* arg0, f32 arg1, f32 arg2, f32 arg3, struct_f
     Matrix_scale(arg3, arg3, 1.0f, MTXMODE_APPLY);
 
     OPEN_DISPS(arg0);
+    OPEN_CUSTOM_POLY_OPA();
 
-    gfx = POLY_OPA_DISP;
-
-    gDPPipeSync(gfx++);
-    gSPMatrix(gfx++, _Matrix_to_Mtx_new(arg0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gDPPipeSync(__polyOpa++);
+    gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(arg0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     temp_a1 = &letter_tex_data_table_837[var_t0];
 
-    gSPSegment(gfx++, 0x09, Lib_SegmentedToVirtual(temp_a1->pal));
-    gSPSegment(gfx++, 0x0A, Lib_SegmentedToVirtual(temp_a1->tex));
-    gDPSetAlphaCompare(gfx++, G_AC_THRESHOLD);
-    gDPSetBlendColor(gfx++, 255, 255, 255, 40);
+    gSPSegment(__polyOpa++, 0x09, Lib_SegmentedToVirtual(temp_a1->pal));
+    gSPSegment(__polyOpa++, 0x0A, Lib_SegmentedToVirtual(temp_a1->tex));
+    gDPSetAlphaCompare(__polyOpa++, G_AC_THRESHOLD);
+    gDPSetBlendColor(__polyOpa++, 255, 255, 255, 40);
 
     if (arg5 != 0) {
-        gDPSetPrimColor(gfx++, 0, 0xFF, 255, 255, 255, 255);
+        gDPSetPrimColor(__polyOpa++, 0, 0xFF, 255, 255, 255, 255);
     } else {
-        gDPSetPrimColor(gfx++, 0, 0x82, 255, 110, 105, 255);
+        gDPSetPrimColor(__polyOpa++, 0, 0x82, 255, 110, 105, 255);
     }
 
     if (arg6 == 0) {
-        gDPSetCombineLERP(gfx++, TEXEL0, PRIMITIVE, PRIM_LOD_FRAC, PRIMITIVE, 0, 0, 0, TEXEL0, TEXEL0, PRIMITIVE,
+        gDPSetCombineLERP(__polyOpa++, TEXEL0, PRIMITIVE, PRIM_LOD_FRAC, PRIMITIVE, 0, 0, 0, TEXEL0, TEXEL0, PRIMITIVE,
                           PRIM_LOD_FRAC, PRIMITIVE, 0, 0, 0, TEXEL0);
     }
 
-    gSPDisplayList(gfx++, D_C012370);
-    gDPPipeSync(gfx++);
-    gDPSetAlphaCompare(gfx++, G_AC_NONE);
-    gDPSetBlendColor(gfx++, 255, 255, 255, 8);
+    gSPDisplayList(__polyOpa++, D_C012370);
+    gDPPipeSync(__polyOpa++);
+    gDPSetAlphaCompare(__polyOpa++, G_AC_NONE);
+    gDPSetBlendColor(__polyOpa++, 255, 255, 255, 8);
 
-    POLY_OPA_DISP = gfx;
-
+    CLOSE_CUSTOM_POLY_OPA();
     CLOSE_DISPS(arg0);
 }
-#else
-void mSM_draw_mail(GraphicsContext* arg0, f32 arg1, f32 arg2, f32 arg3, struct_func_8085CE18_jp_arg4* arg4, s32 arg5,
-                   s32 arg6);
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/submenu/submenu_ovl/m_submenu_ovl/mSM_draw_mail.s")
-#endif
 
 void func_8085D094_jp(Submenu* submenu) {
     struct_8085E9B0_unk_10000* sp2C = &submenu->unk_2C->unk_10000;


### PR DESCRIPTION
When I was working on `ac_t_keitai`, I was stymied by what is, at this point, a classic problem with DnM; I needed to shove a bunch of `if (1) {}`s into its draw function to match. After I finished that file, I thought about why this such a common occurrence and what the developers could have possibly done to make this such a consistent pattern. It wasn't until I looked at this [macro-less version of a draw function](https://decomp.me/scratch/v2l83) I made once a while back that inspiration struck.

The core idea I had is that the developers might have made the `OPEN_DISPS` and `CLOSE_DISPS` macros "symmetrical" in regards to their use of `do {} while (0)`s. To demonstrate what I mean, here is what it would look like when the macros proposed in this PR are expanded:
```c
do {} while (0);
{
    GraphicsContext* __gfxCtx = gfxCtx;
    s32 __dispPad UNUSED;
    do {} while (0);

    [...stuff...]

    do {} while (0);
    (void)0;
}
do {} while (0);
```

You can see how the `do {} while (0)`s at the top of the function have matching `do {} while (0)`s at the bottom of the function. There is a bit of inconsistency regarding the use of these macros in the repo currently, since some files were using an `AC_GCN_` variant that had a `do {} while (0)` in the `AC_GCN_CLOSE_DISP` macro that wasn't present in the regular `CLOSE_DISPS` macro. Regardless of which macro was used, however, the end result was *not* symmetric like I'm proposing here.

I went through the repo and replaced all uses of the `OPEN_DISPS`/`CLOSE_DISPS` macros with my symmetric alternatives (including the `AC_GCN_` variants), and not only did almost everything more or less work perfectly, it also allowed me to eliminate a lot of fake matches and `if (1) {}`s. Some notes:
- In `m_rcp`, these macros worked fine as-is, but they didn't fix the fake match in `DisplayList_initialize`. I found that by scoping `unk_008`, the fake match could be eliminated, so I took the liberty of doing that.
- In `ac_train_window`, I really struggled to clean up any of the fake matches even with the new macros. I think there is something more to this file that we're still missing.
- In `m_submenu_ovl`, there's a particular quirk of `mSM_setup_view` that remains unsolved. I couldn't eliminate *all* of the `if (1) {}`s, just most of them. By using the symmetric macros and `OPEN_CUSTOM_POLY_OPA_DISP`/`CLOSE_CUSTOM_POLY_OPA_DISP`, I was able to eliminate all but two of them. By then scoping `Game_Play1938* view;`, I was able to eliminate all but one of them. That last one is super tricky, and I don't have a great idea how to solve it yet. I suspect something is slightly off about the `OPEN_CUSTOM_POLY_X_DISP`/`CLOSE_CUSTOM_POLY_X_DISP` macros, but I don't want to mess with them too much yet; I want to keep this PR's scope relatively limited, and there's also a conflicting thing in another file that motivates me to leave this alone for now.
- Also in `m_submenu_ovl`, the "stack issues" mentioned in `mSM_draw_mail` seem to just be fixed by using the `OPEN_CUSTOM_POLY_OPA_DISP`/`CLOSE_CUSTOM_POLY_OPA_DISP` macros, so I took the liberty of matching that function too.
- In `ac_psnowman` (not committed to the repo yet), the draw function matches just fine with these new macros, and doing so eliminates the need for an `if (1) {}`, as seen in [this scratch](https://decomp.me/scratch/AamrO). However, it looks like if you add a single `if (1) {}` to that function, it breaks. This is the conflicting thing I mentioned in regards to `mSM_setup_view`. We *could* add another `do {} while (0)` to the `OPEN_CUSTOM_POLY_X_DISP`/`CLOSE_CUSTOM_POLY_X_DISP` macros to fix that function, but then we would break `aPSM_actor_draw`. This suggests to me that there's still something about these graphics macros we've yet to figure out.

I do also realize that there just aren't a lot of examples of decompiled draw functions currently in the repo, and thus by making such a change to the macros, it might cause us problems down the road. However, I don't want perfect to be the enemy of good here; these macros seem to work in every single place I could try them, and they fix a lot of fake matches. I would rather have these macros, which might have the *potential* of causing problems later, over the macros that are currently in the repo, which we *know* are currently causing problems today.