### PR TITLE
Update GraphicsContext macros

### DIFF
--- a/include/gfx.h
+++ b/include/gfx.h
@@ -19,7 +19,7 @@ typedef struct GraphicsContext {
     /* 0x280 */ TwoHeadGfxArena overlay;
     /* 0x290 */ TwoHeadGfxArena polyOpa;
     /* 0x2A0 */ TwoHeadGfxArena polyXlu;
-    /* 0x2B0 */ TwoHeadGfxArena unk_2B0;
+    /* 0x2B0 */ TwoHeadGfxArena font;
     /* 0x2C0 */ TwoHeadGfxArena shadow;
     /* 0x2D0 */ TwoHeadGfxArena light;
     /* 0x2E0 */ UNK_TYPE1 unk_2E0[0x4];
@@ -39,7 +39,7 @@ typedef struct GraphicsContext {
 #define OVERLAY_DISP __gfxCtx->overlay.p
 #define POLY_OPA_DISP __gfxCtx->polyOpa.p
 #define POLY_XLU_DISP __gfxCtx->polyXlu.p
-#define UNK_2B0_DISP __gfxCtx->unk_2B0.p
+#define FONT_DISP __gfxCtx->font.p
 #define SHADOW_DISP __gfxCtx->shadow.p
 #define LIGHT_DISP __gfxCtx->light.p
 
@@ -49,13 +49,77 @@ typedef struct GraphicsContext {
     do {} while (0);                        \
     {                                       \
         GraphicsContext* __gfxCtx = gfxCtx; \
-        s32 __dispPad UNUSED;               \
+        s32 __dispPad = 0;                  \
         do {} while (0)
 
 #define CLOSE_DISPS(gfxCtx) \
         do {} while (0);    \
-        (void)0;            \
+        (void)__dispPad;    \
     }                       \
+    do {} while (0)
+
+#define OPEN_POLY_OPA_DISP(g)                     \
+    do {} while (0);                              \
+    OPEN_DISPS(g);                                \
+    {                                             \
+        Gfx* __polyOpa = __gfxCtx->polyOpa.p;     \
+        s32 __poly_opa_gfx = 0;                   \
+    do {} while (0)
+
+#define CLOSE_POLY_OPA_DISP(g)                     \
+    do {} while (0);                               \
+        (void)__poly_opa_gfx;                      \
+        __gfxCtx->polyOpa.p = __polyOpa;           \
+    }                                              \
+    CLOSE_DISPS(g);                                \
+    do {} while (0)
+
+#define OPEN_POLY_XLU_DISP(g)                     \
+    do {} while (0);                              \
+    OPEN_DISPS(g);                                \
+    {                                             \
+        Gfx* __polyXlu = __gfxCtx->polyXlu.p;     \
+        s32 __poly_xlu_gfx = 0;                   \
+    do {} while (0)
+
+#define CLOSE_POLY_XLU_DISP(g)                     \
+    do {} while (0);                               \
+        (void)__poly_xlu_gfx;                      \
+        __gfxCtx->polyXlu.p = __polyXlu;           \
+    }                                              \
+    CLOSE_DISPS(g);                                \
+    do {} while (0)
+
+#define OPEN_LIGHT_DISP(g)                    \
+    do {} while (0);                          \
+    OPEN_DISPS(g);                            \
+    {                                         \
+        Gfx* __light = __gfxCtx->light.p;     \
+        s32 __light_gfx = 0;                  \
+        do {} while (0)
+
+#define CLOSE_LIGHT_DISP(g)              \
+       do {} while (0);                  \
+        __gfxCtx->light.p = __light;     \
+        (void)__light_gfx;               \
+    }                                    \
+    CLOSE_DISPS(g);                      \
+    do {} while (0)
+
+#define OPEN_SHADOW_DISP(g)                     \
+    do {} while (0);                            \
+    OPEN_DISPS(g);                              \
+    {                                           \
+        Gfx* __shadow_gfx = __gfxCtx->shadow.p; \
+        s32 __shadow_opened = 0;                \
+        do {} while (0)
+
+#define CLOSE_SHADOW_DISP(g)                \
+       do {} while (0);                     \
+        (void)__shadow_opened;              \
+        __gfxCtx->shadow.p = __shadow_gfx;  \
+    }                                       \
+    CLOSE_DISPS(g);                         \
     do {} while (0)
 
 #define qs1616(e) ((s32)((e)*0x00010000))

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -138,9 +138,9 @@ void game_draw_first(GraphicsContext* gfxCtx) {
     gSPSegment(OVERLAY_DISP++, 0x0F, gfxCtx->unk_2E4);
     gSPSegment(OVERLAY_DISP++, 0x0E, temp_v0);
 
-    gSPSegment(UNK_2B0_DISP++, 0x00, NULL);
-    gSPSegment(UNK_2B0_DISP++, 0x0F, gfxCtx->unk_2E4);
-    gSPSegment(UNK_2B0_DISP++, 0x0E, temp_v0);
+    gSPSegment(FONT_DISP++, 0x00, NULL);
+    gSPSegment(FONT_DISP++, 0x0F, gfxCtx->unk_2E4);
+    gSPSegment(FONT_DISP++, 0x0E, temp_v0);
 
     gSPSegment(SHADOW_DISP++, 0x00, NULL);
     gSPSegment(SHADOW_DISP++, 0x0F, gfxCtx->unk_2E4);

--- a/src/code/m_rcp.c
+++ b/src/code/m_rcp.c
@@ -463,21 +463,21 @@ void DisplayList_initialize(GraphicsContext* gfxCtx, u8 clearR, u8 clearG, u8 cl
     gSPDisplayList(POLY_OPA_DISP++, RSP_RDP_clear_data);
     gSPDisplayList(POLY_XLU_DISP++, RSP_RDP_clear_data);
     gSPDisplayList(OVERLAY_DISP++, RSP_RDP_clear_data);
-    gSPDisplayList(UNK_2B0_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(FONT_DISP++, RSP_RDP_clear_data);
     gSPDisplayList(SHADOW_DISP++, z_gsCPModeSet_Data[2]);
     gSPDisplayList(LIGHT_DISP++, z_gsCPModeSet_Data[2]);
 
     gDPSetScissor(POLY_OPA_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     gDPSetScissor(POLY_XLU_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     gDPSetScissor(OVERLAY_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-    gDPSetScissor(UNK_2B0_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    gDPSetScissor(FONT_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     gDPSetScissor(SHADOW_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     gDPSetScissor(LIGHT_DISP++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
     gDPSetColorImage(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
     gDPSetColorImage(POLY_XLU_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
     gDPSetColorImage(OVERLAY_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
-    gDPSetColorImage(UNK_2B0_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
+    gDPSetColorImage(FONT_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
     gDPSetColorImage(SHADOW_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
     gDPSetColorImage(LIGHT_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH, gfxCtx->unk_2E4);
 
@@ -487,7 +487,7 @@ void DisplayList_initialize(GraphicsContext* gfxCtx, u8 clearR, u8 clearG, u8 cl
         gDPSetDepthImage(POLY_OPA_DISP++, unk_008);
         gDPSetDepthImage(POLY_XLU_DISP++, unk_008);
         gDPSetDepthImage(OVERLAY_DISP++, unk_008);
-        gDPSetDepthImage(UNK_2B0_DISP++, unk_008);
+        gDPSetDepthImage(FONT_DISP++, unk_008);
         gDPSetDepthImage(SHADOW_DISP++, unk_008);
         gDPSetDepthImage(LIGHT_DISP++, unk_008);
     }

--- a/src/overlays/actors/ovl_Ball/ac_ball.c
+++ b/src/overlays/actors/ovl_Ball/ac_ball.c
@@ -768,34 +768,18 @@ void aBALL_actor_move(Actor* thisx, Game_Play* game_play) {
     aBALL_status_check(this, game_play);
 }
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aBALL_actor_draw(Actor* thisx, Game_Play* game_play) {
     GraphicsContext* gfxCtx = game_play->state.gfxCtx;
     Ball* this = THIS;
 
-    OPEN_DISPS(gfxCtx);
-    OPEN_CUSTOM_POLY_OPA();
+    OPEN_POLY_OPA_DISP(gfxCtx);
     gSPSegment(__polyOpa++, 0x06, this->segment);
     Matrix_translate(0.0f, this->height, 0.0f, 1);
     Matrix_rotateXYZ(this->ballRot.x, this->ballRot.y, this->ballRot.z, MTXMODE_APPLY);
     gDPPipeSync(__polyOpa++);
     gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(__polyOpa++, ball_model_tbl[this->type]);
-    CLOSE_CUSTOM_POLY_OPA();
-    CLOSE_DISPS(gfxCtx);
+    CLOSE_POLY_OPA_DISP(gfxCtx);
 }
 
 // Original name unknown.

--- a/src/overlays/actors/ovl_Bee/ac_bee.c
+++ b/src/overlays/actors/ovl_Bee/ac_bee.c
@@ -301,20 +301,6 @@ void aBEE_actor_move(Actor* thisx, Game_Play* game_play) {
     }
 }
 
-#define OPEN_CUSTOM_POLY_XLU()                \
-    {                                         \
-        Gfx* __polyXlu = __gfxCtx->polyXlu.p; \
-        int __xlu_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_XLU()      \
-    __gfxCtx->polyXlu.p = __polyXlu; \
-    (void)__xlu_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aBEE_actor_draw(Actor* thisx, Game_Play* game_play) {
     Bee* this = THIS;
     s32 mtxIndex = game_play->state.frameCounter & 1;
@@ -332,12 +318,10 @@ void aBEE_actor_draw(Actor* thisx, Game_Play* game_play) {
             _texture_z_light_fog_prim_xlu(game_play->state.gfxCtx);
             Setpos_HiliteReflect_xlu_init(&this->actor.world.pos, game_play);
 
-            OPEN_DISPS(game_play->state.gfxCtx);
-            OPEN_CUSTOM_POLY_XLU();
+            OPEN_POLY_XLU_DISP(game_play->state.gfxCtx);
             gDPSetPrimColor(__polyXlu++, 0, 255, 0, 0, 0, this->alpha);
             gSPSegment(__polyXlu++, 0x08, texScroll);
-            CLOSE_CUSTOM_POLY_XLU();
-            CLOSE_DISPS(game_play->state.gfxCtx);
+            CLOSE_POLY_XLU_DISP(game_play->state.gfxCtx);
             cKF_Si3_draw_R_SV(game_play, &this->skeletonInfo, this->mtx[mtxIndex], NULL, NULL, this);
             Matrix_pull();
         }

--- a/src/overlays/actors/ovl_Dump/ac_dump.c
+++ b/src/overlays/actors/ovl_Dump/ac_dump.c
@@ -162,20 +162,6 @@ void aDUM_actor_init(Actor* thisx, Game_Play* game_play) {
     this->actor.update = aDUM_actor_move;
 }
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aDUM_actor_draw(UNUSED Actor* thisx, Game_Play* game_play) {
     static Gfx* model[2] = {
         dump_s_DL_model,
@@ -188,11 +174,11 @@ void aDUM_actor_draw(UNUSED Actor* thisx, Game_Play* game_play) {
     s32 type = (common_data.time.season == WINTER) ? 1 : 0;
     Mtx* mtx;
 
-    OPEN_DISPS(gfxCtx);
     object = common_data.clip.unk_08C->unk_AC(0x28);
     palette = common_data.clip.unk_08C->unk_450(0x51);
     _texture_z_light_fog_prim_npc(gfxCtx);
-    OPEN_CUSTOM_POLY_OPA();
+
+    OPEN_POLY_OPA_DISP(gfxCtx);
     gSPSegment(__polyOpa++, 0x08, palette);
     gSegments[6] = (uintptr_t)OS_PHYSICAL_TO_K0(object);
     gSPSegment(__polyOpa++, 0x06, object);
@@ -202,8 +188,7 @@ void aDUM_actor_draw(UNUSED Actor* thisx, Game_Play* game_play) {
     if (mtx != NULL) {
         gSPMatrix(__polyOpa++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(__polyOpa++, model[type]);
-        CLOSE_CUSTOM_POLY_OPA();
+        CLOSE_POLY_OPA_DISP(gfxCtx);
     }
     common_data.clip.unk_074->unk_04(game_play, &aDUM_shadow_data, 40);
-    CLOSE_DISPS(gfxCtx);
 }

--- a/src/overlays/actors/ovl_Fuusen/ac_fuusen.c
+++ b/src/overlays/actors/ovl_Fuusen/ac_fuusen.c
@@ -406,19 +406,6 @@ Gfx* func_80AAE10C_jp(u8 red, u8 blue, u8 green, u8 alpha, Game_Play* game_play)
 extern Gfx present_DL_mode[];
 extern Vtx present_DL_vtx[];
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    while (0)
-
 void aFSN_actor_draw(Actor* thisx, Game_Play* game_play) {
     static xyz_t offset0 = { 0.0f, 0.0f, 0.0f };
     Fuusen* this = THIS;
@@ -441,8 +428,7 @@ void aFSN_actor_draw(Actor* thisx, Game_Play* game_play) {
         if ((this->processNum != FSN_PROCESS_ESCAPE) || (this->escapeTimer == 777) ||
             ((this->processNum == FSN_PROCESS_ESCAPE) && (this->unk_18C == 0))) {
             _texture_z_light_fog_prim(game_play->state.gfxCtx);
-            OPEN_DISPS(game_play->state.gfxCtx);
-            OPEN_CUSTOM_POLY_OPA();
+            OPEN_POLY_OPA_DISP(game_play->state.gfxCtx);
             Matrix_translate(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, 0);
             Matrix_scale(0.01f, 0.01f, 0.01f, 1);
             Matrix_RotateX(this->actor.shape.rot.x, MTXMODE_APPLY);
@@ -452,8 +438,7 @@ void aFSN_actor_draw(Actor* thisx, Game_Play* game_play) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(__polyOpa++, present_DL_mode);
             gSPDisplayList(__polyOpa++, present_DL_vtx);
-            CLOSE_CUSTOM_POLY_OPA();
-            CLOSE_DISPS(game_play->state.gfxCtx);
+            CLOSE_POLY_OPA_DISP(game_play->state.gfxCtx);
         }
         OPEN_DISPS(game_play->state.gfxCtx);
         gSPSegment(POLY_OPA_DISP++, 0x06, segment);

--- a/src/overlays/actors/ovl_Kago/ac_kago.c
+++ b/src/overlays/actors/ovl_Kago/ac_kago.c
@@ -104,20 +104,6 @@ void aKAG_actor_init(Actor* thisx, Game_Play* game_play) {
     this->actor.update = aKAG_actor_move;
 }
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aKAG_actor_draw(Actor* thisx, Game_Play* game_play) {
     static Gfx* model[] = { kago_r_DL_model, kago_w_DL_model };
     GraphicsContext* gfxCtx = game_play->state.gfxCtx;
@@ -126,18 +112,16 @@ void aKAG_actor_draw(Actor* thisx, Game_Play* game_play) {
     u16* palette = common_data.clip.unk_08C->unk_450(this->structurePalette);
     Mtx* mtx;
 
-    OPEN_DISPS(gfxCtx);
     mtx = _Matrix_to_Mtx_new(gfxCtx);
     if (mtx != NULL) {
         _texture_z_light_fog_prim(gfxCtx);
-        OPEN_CUSTOM_POLY_OPA();
+        OPEN_POLY_OPA_DISP(gfxCtx);
         gSPSegment(__polyOpa++, 0x08, palette);
         gSegments[6] = (uintptr_t)OS_PHYSICAL_TO_K0(object);
         gSPSegment(__polyOpa++, 0x06, object);
         gSPMatrix(__polyOpa++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(__polyOpa++, model[this->type]);
-        CLOSE_CUSTOM_POLY_OPA();
+        CLOSE_POLY_OPA_DISP(gfxCtx);
         common_data.clip.unk_074->unk_04(game_play, &aKAG_shadow_data, this->structureType);
     }
-    CLOSE_DISPS(gfxCtx);
 }

--- a/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
+++ b/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
@@ -108,20 +108,6 @@ void aKOI_actor_init(Actor* thisx, Game_Play* game_play) {
     this->actor.update = aKOI_actor_move;
 }
 
-#define OPEN_POLY_OPA_DISPS()                 \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_POLY_OPA_DISPS()       \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 extern u16 aKOI_obj_e_koinobori_a_pal[];
 extern u16 obj_e_koinobori_b_pal[];
 #include "assets/jp/overlays/actors/ovl_Koinobori/aKOI_obj_e_koinobori_a_pal.palette.inc.c"
@@ -140,15 +126,13 @@ void aKOI_actor_draw(Actor* thisx, Game_Play* game_play) {
         object = common_data.clip.unk_08C->unk_AC(0x27);
         palette = common_data.clip.unk_08C->unk_450(0x50);
         _texture_z_light_fog_prim_npc(gfxCtx);
-        OPEN_DISPS(gfxCtx);
-        OPEN_POLY_OPA_DISPS();
+        OPEN_POLY_OPA_DISP(gfxCtx);
         gSPSegment(__polyOpa++, 0x08, palette);
         gSPSegment(__polyOpa++, 0x09, Lib_SegmentedToVirtual(&obj_e_koinobori_b_pal));
         gSPSegment(__polyOpa++, 0x0A, Lib_SegmentedToVirtual(&aKOI_obj_e_koinobori_a_pal));
         gSegments[6] = OS_K0_TO_PHYSICAL(object);
         gSPSegment(__polyOpa++, 0x06, object);
-        CLOSE_POLY_OPA_DISPS();
-        CLOSE_DISPS(gfxCtx);
+        CLOSE_POLY_OPA_DISP(gfxCtx);
         cKF_Si3_draw_R_SV(game_play, &this->skeletonInfo, mtx, NULL, NULL, this);
         common_data.clip.unk_074->unk_04(game_play, &aKOI_shadow_data, 0x27);
     }

--- a/src/overlays/actors/ovl_Sample/ac_sample.c
+++ b/src/overlays/actors/ovl_Sample/ac_sample.c
@@ -152,20 +152,6 @@ void Ac_Sample_Actor_ct(Actor* thisx, Game_Play* play) {
     this->segment = play->objectExchangeBank.status[thisx->unk_026].segment;
 }
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void Ac_Sample_Actor_draw_normal(Sample* this, Game_Play* play) {
     UNUSED s32 pad;
     SkeletonInfoR* info = &this->skeletonInfo;
@@ -175,17 +161,13 @@ void Ac_Sample_Actor_draw_normal(Sample* this, Game_Play* play) {
 
         _texture_z_light_fog_prim(play->state.gfxCtx);
 
-        OPEN_DISPS(play->state.gfxCtx);
-        OPEN_CUSTOM_POLY_OPA();
+        OPEN_POLY_OPA_DISP(play->state.gfxCtx);
         gDPLoadTextureBlockS(__polyOpa++, hnw_tmem_txt, G_IM_FMT_I, G_IM_SIZ_8b, 64, 64, 0, G_TX_MIRROR | G_TX_WRAP,
                              G_TX_MIRROR | G_TX_WRAP, 7, 7, G_TX_NOLOD, G_TX_NOLOD);
 
         gDPLoadTLUT_pal16(__polyOpa++, 15, hnw_face);
         gDPSetTextureLUT(__polyOpa++, G_TT_RGBA16);
-
-        CLOSE_CUSTOM_POLY_OPA();
-
-        CLOSE_DISPS(play->state.gfxCtx);
+        CLOSE_POLY_OPA_DISP(play->state.gfxCtx);
 
         cKF_Si3_draw_R_SV(play, info, mtx, NULL, NULL, NULL);
     }

--- a/src/overlays/actors/ovl_T_Hanabi/ac_t_hanabi.c
+++ b/src/overlays/actors/ovl_T_Hanabi/ac_t_hanabi.c
@@ -83,18 +83,6 @@ void aTHB_actor_move(Actor* thisx, Game_Play* game_play UNUSED) {
     this->process(this);
 }
 
-#define OPEN_POLY_OPA_DISPS()                 \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        while (0)
-
-#define CLOSE_POLY_OPA_DISPS()       \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    while (0)
-
 void aTHB_actor_draw(Actor* thisx, Game_Play* game_play) {
     static xyz_t D_80A200A4_jp = { 0.0f, 0.0f, 0.0f };
     T_Hanabi* this = THIS;
@@ -112,10 +100,8 @@ void aTHB_actor_draw(Actor* thisx, Game_Play* game_play) {
 
     Matrix_scale(thisx->scale.x, thisx->scale.y, thisx->scale.z, MTXMODE_APPLY);
     _texture_z_light_fog_prim_npc(gfxCtx);
-    OPEN_DISPS(gfxCtx);
-    OPEN_POLY_OPA_DISPS();
+    OPEN_POLY_OPA_DISP(gfxCtx);
     gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(__polyOpa++, &main_utiwa1_model);
-    CLOSE_POLY_OPA_DISPS();
-    CLOSE_DISPS(gfxCtx);
+    CLOSE_POLY_OPA_DISP(gfxCtx);
 }

--- a/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
+++ b/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
@@ -132,20 +132,6 @@ void aTKT_actor_move(Actor* thisx, Game_Play* game_play) {
     this->process(this);
 }
 
-#define OPEN_POLY_OPA_DISPS()                 \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_POLY_OPA_DISPS()       \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aTKT_actor_draw(Actor* thisx, Game_Play* game_play) {
     static xyz_t D_80A1F9F4_jp = { 0.0f, 0.0f, 0.0f };
     T_Keitai* this = THIS;
@@ -156,6 +142,8 @@ void aTKT_actor_draw(Actor* thisx, Game_Play* game_play) {
     func_80A1F58C_jp(this, game_play);
 
     mtx = GRAPH_ALLOC_NO_ALIGN(gfxCtx, sizeof(Mtx) * skeletonInfo->skeleton->unk01);
+    
+    if (1) {} /* FAKE */
 
     if (mtx != NULL) {
         if (this->toolActor.unk1B8 == 1) {
@@ -170,15 +158,12 @@ void aTKT_actor_draw(Actor* thisx, Game_Play* game_play) {
 
         _texture_z_light_fog_prim_npc(gfxCtx);
 
-        OPEN_DISPS(gfxCtx);
-        OPEN_POLY_OPA_DISPS();
-
+        OPEN_POLY_OPA_DISP(gfxCtx);
         Matrix_scale(this->toolActor.actor.scale.x, this->toolActor.actor.scale.y, this->toolActor.actor.scale.z,
                      MTXMODE_APPLY);
         gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-        CLOSE_POLY_OPA_DISPS();
-        CLOSE_DISPS(gfxCtx);
+        CLOSE_POLY_OPA_DISP(gfxCtx);
 
         cKF_Si3_draw_R_SV(game_play, skeletonInfo, mtx, NULL, NULL, NULL);
     }

--- a/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
+++ b/src/overlays/actors/ovl_T_Keitai/ac_t_keitai.c
@@ -142,7 +142,7 @@ void aTKT_actor_draw(Actor* thisx, Game_Play* game_play) {
     func_80A1F58C_jp(this, game_play);
 
     mtx = GRAPH_ALLOC_NO_ALIGN(gfxCtx, sizeof(Mtx) * skeletonInfo->skeleton->unk01);
-    
+
     if (1) {} /* FAKE */
 
     if (mtx != NULL) {

--- a/src/overlays/actors/ovl_Tama/ac_tama.c
+++ b/src/overlays/actors/ovl_Tama/ac_tama.c
@@ -90,20 +90,6 @@ void aTAM_actor_init(Actor* thisx, Game_Play* game_play) {
     this->actor.update = aTAM_actor_move;
 }
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void aTAM_actor_draw(Actor* thisx, Game_Play* game_play) {
     static Gfx* model[2] = { kago_r_ball_DL_model, kago_w_ball_DL_model };
     GraphicsContext* gfxCtx = game_play->state.gfxCtx;
@@ -114,8 +100,7 @@ void aTAM_actor_draw(Actor* thisx, Game_Play* game_play) {
 
     _texture_z_light_fog_prim(gfxCtx);
 
-    OPEN_DISPS(gfxCtx);
-    OPEN_CUSTOM_POLY_OPA();
+    OPEN_POLY_OPA_DISP(gfxCtx);
     gSPSegment(__polyOpa++, 0x08, palette);
     gSegments[6] = (uintptr_t)OS_PHYSICAL_TO_K0(object);
     gSPSegment(__polyOpa++, 0x06, object);
@@ -124,7 +109,6 @@ void aTAM_actor_draw(Actor* thisx, Game_Play* game_play) {
     if (mtx != NULL) {
         gSPMatrix(__polyOpa++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(__polyOpa++, model[this->type]);
-        CLOSE_CUSTOM_POLY_OPA();
+        CLOSE_POLY_OPA_DISP(gfxCtx);
     }
-    CLOSE_DISPS(gfxCtx);
 }

--- a/src/overlays/actors/ovl_Toudai/ac_toudai.c
+++ b/src/overlays/actors/ovl_Toudai/ac_toudai.c
@@ -205,48 +205,6 @@ s32 aTOU_actor_draw_before(Game_Play* game_play UNUSED, SkeletonInfoR* skeletonI
     return 1;
 }
 
-#define OPEN_POLY_OPA_DISPS()                 \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_POLY_OPA_DISPS()       \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
-#define OPEN_POLY_XLU_DISPS()                 \
-    {                                         \
-        Gfx* __polyXlu = __gfxCtx->polyXlu.p; \
-        int __xlu_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_POLY_XLU_DISPS()       \
-    __gfxCtx->polyXlu.p = __polyXlu; \
-    (void)__xlu_opened;              \
-    }                                \
-    do {                             \
-    } while (0);
-
-#define OPEN_LIGHT_DISPS()                \
-    {                                     \
-        Gfx* __light = __gfxCtx->light.p; \
-        int __light_opened = 0;           \
-        do {                              \
-        } while (0)
-
-#define CLOSE_LIGHT_DISPS()      \
-    __gfxCtx->light.p = __light; \
-    (void)__light_opened;        \
-    }                            \
-    do {                         \
-    } while (0)
-
 extern Gfx obj_s_toudai_light_model[];
 extern Gfx obj_w_toudai_light_model[];
 
@@ -270,8 +228,7 @@ s32 aTOU_actor_draw_after(Game_Play* game_play, SkeletonInfoR* skeletonInfo UNUS
             object = common_data.clip.unk_08C->unk_AC(0x2D);
             palette = common_data.clip.unk_08C->unk_450(0x5A);
             _texture_z_light_fog_prim_light(gfxCtx);
-            OPEN_DISPS(gfxCtx);
-            OPEN_LIGHT_DISPS();
+            OPEN_LIGHT_DISP(gfxCtx);
             gSPSegment(__light++, 8, palette);
             gSPSegment(__light++, 6, object);
             prmcol.b = this->unk2C8;
@@ -283,8 +240,7 @@ s32 aTOU_actor_draw_after(Game_Play* game_play, SkeletonInfoR* skeletonInfo UNUS
             gDPSetPrimColor(__light++, 0, (u8)this->unk2D0, prmcol.r, prmcol.g, prmcol.b, prmcol.a);
             gSPMatrix(__light++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(__light++, mdl[type]);
-            CLOSE_LIGHT_DISPS();
-            CLOSE_DISPS(gfxCtx);
+            CLOSE_LIGHT_DISP(gfxCtx);
         }
     }
     return 1;
@@ -293,14 +249,13 @@ s32 aTOU_actor_draw_after(Game_Play* game_play, SkeletonInfoR* skeletonInfo UNUS
 void aTOU_actor_draw(Actor* thisx, Game_Play* game_play) {
     UNUSED s32 pad;
     GraphicsContext* gfxCtx = game_play->state.gfxCtx;
-    UNUSED s32 pad2[2];
     Toudai* this = THIS;
+    SkeletonInfoR* skeletonInfo = &this->skeletonInfo;
+    Mtx* mtx;
     s32 object;
     u16* palette;
-    UNUSED s32 pad3;
-    Mtx* mtx;
+    u8 numberOfDisplayLists = skeletonInfo->skeleton->unk01;
     xyz_t* worldPosition = &this->actor.world.pos;
-    u8 numberOfDisplayLists = this->skeletonInfo.skeleton->unk01;
 
     mtx = GRAPH_ALLOC_NO_ALIGN(gfxCtx, numberOfDisplayLists * sizeof(Mtx));
 
@@ -309,23 +264,21 @@ void aTOU_actor_draw(Actor* thisx, Game_Play* game_play) {
         palette = common_data.clip.unk_08C->unk_450(0x5A);
 
         _texture_z_light_fog_prim_npc(gfxCtx);
-        OPEN_DISPS(gfxCtx);
-        OPEN_POLY_OPA_DISPS();
+        OPEN_POLY_OPA_DISP(gfxCtx);
         gSPSegment(__polyOpa++, 0x8, palette);
         gSegments[6] = OS_K0_TO_PHYSICAL(object);
         gSPSegment(__polyOpa++, 0x6, object);
-        CLOSE_POLY_OPA_DISPS();
+        CLOSE_POLY_OPA_DISP(gfxCtx);
 
         _texture_z_light_fog_prim_xlu(gfxCtx);
-        OPEN_POLY_XLU_DISPS();
+        OPEN_POLY_XLU_DISP(gfxCtx);
         gSPSegment(__polyXlu++, 0x8, palette);
         gSPSegment(__polyXlu++, 0x6, object);
-        CLOSE_POLY_XLU_DISPS();
-        CLOSE_DISPS(gfxCtx);
+        CLOSE_POLY_XLU_DISP(gfxCtx);
 
         Setpos_HiliteReflect_init(worldPosition, game_play);
         Setpos_HiliteReflect_xlu_init(worldPosition, game_play);
-        cKF_Si3_draw_R_SV(game_play, &this->skeletonInfo, mtx, aTOU_actor_draw_before, aTOU_actor_draw_after, this);
+        cKF_Si3_draw_R_SV(game_play, skeletonInfo, mtx, aTOU_actor_draw_before, aTOU_actor_draw_after, this);
         common_data.clip.unk_074->unk_04(game_play, &aTOU_shadow_data, 0x2D);
     }
 }

--- a/src/overlays/gamestates/ovl_play/m_play.c
+++ b/src/overlays/gamestates/ovl_play/m_play.c
@@ -548,21 +548,21 @@ void func_80803810_jp(Game_Play* game_play, GraphicsContext* gfxCtx) {
     gSPSegment(POLY_OPA_DISP++, 0x00, NULL);
     gSPSegment(POLY_XLU_DISP++, 0x00, NULL);
     gSPSegment(OVERLAY_DISP++, 0x00, NULL);
-    gSPSegment(UNK_2B0_DISP++, 0x00, NULL);
+    gSPSegment(FONT_DISP++, 0x00, NULL);
     gSPSegment(SHADOW_DISP++, 0x00, NULL);
     gSPSegment(LIGHT_DISP++, 0x00, NULL);
 
     gSPSegment(POLY_OPA_DISP++, 0x04, temp_v0);
     gSPSegment(POLY_XLU_DISP++, 0x04, temp_v0);
     gSPSegment(OVERLAY_DISP++, 0x04, temp_v0);
-    gSPSegment(UNK_2B0_DISP++, 0x04, temp_v0);
+    gSPSegment(FONT_DISP++, 0x04, temp_v0);
     gSPSegment(SHADOW_DISP++, 0x04, temp_v0);
     gSPSegment(LIGHT_DISP++, 0x04, temp_v0);
 
     gSPSegment(POLY_OPA_DISP++, 0x02, game_play->unk_010C);
     gSPSegment(POLY_XLU_DISP++, 0x02, game_play->unk_010C);
     gSPSegment(OVERLAY_DISP++, 0x02, game_play->unk_010C);
-    gSPSegment(UNK_2B0_DISP++, 0x02, game_play->unk_010C);
+    gSPSegment(FONT_DISP++, 0x02, game_play->unk_010C);
     gSPSegment(SHADOW_DISP++, 0x02, game_play->unk_010C);
     gSPSegment(LIGHT_DISP++, 0x02, game_play->unk_010C);
 

--- a/src/overlays/submenu/submenu_ovl/m_submenu_ovl.c
+++ b/src/overlays/submenu/submenu_ovl/m_submenu_ovl.c
@@ -602,20 +602,6 @@ s32 add_trigger_954[] = { R_CBUTTONS, U_CBUTTONS, L_CBUTTONS, D_CBUTTONS };
 
 f32 move_data_1027[2][4] = { { 2.0f, 0.0f, 300.0f, 1.0f }, { 0.5f, 120.0f, 0.0f, -1.0f } };
 
-#define OPEN_CUSTOM_POLY_OPA()                \
-    {                                         \
-        Gfx* __polyOpa = __gfxCtx->polyOpa.p; \
-        int __opa_opened = 0;                 \
-        do {                                  \
-        } while (0)
-
-#define CLOSE_CUSTOM_POLY_OPA()      \
-    __gfxCtx->polyOpa.p = __polyOpa; \
-    (void)__opa_opened;              \
-    }                                \
-    do {                             \
-    } while (0)
-
 void mSM_setup_view(Submenu* submenu, GraphicsContext* gfxCtx, s32 arg1) {
     Mtx* mtx;
 
@@ -627,8 +613,7 @@ void mSM_setup_view(Submenu* submenu, GraphicsContext* gfxCtx, s32 arg1) {
         mtx = submenu->unk_2C->unk_1072C;
     }
 
-    OPEN_DISPS(gfxCtx);
-    OPEN_CUSTOM_POLY_OPA();
+    OPEN_POLY_OPA_DISP(gfxCtx);
 
     if (arg1 == 0) {
         View* view;
@@ -647,25 +632,15 @@ void mSM_setup_view(Submenu* submenu, GraphicsContext* gfxCtx, s32 arg1) {
         gDPSetScissor(__polyOpa++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     }
 
-    //! FAKE
-    if (1) {}
-
     gSPMatrix(__polyOpa++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 
-    CLOSE_CUSTOM_POLY_OPA();
-    CLOSE_DISPS(gfxCtx);
+    CLOSE_POLY_OPA_DISP(gfxCtx);
 }
 
 void mSM_set_char_matrix(GraphicsContext* gfxCtx) {
-    Gfx* gfx;
-
-    OPEN_DISPS(gfxCtx);
-
-    gfx = POLY_OPA_DISP;
-    gSPMatrix(gfx++, &Mtx_clear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    POLY_OPA_DISP = gfx;
-
-    CLOSE_DISPS(gfxCtx);
+    OPEN_POLY_OPA_DISP(gfxCtx);
+    gSPMatrix(__polyOpa++, &Mtx_clear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    CLOSE_POLY_OPA_DISP(gfxCtx);
 }
 
 #ifdef NON_EQUIVALENT
@@ -1157,8 +1132,7 @@ void mSM_draw_mail(GraphicsContext* arg0, f32 arg1, f32 arg2, f32 arg3, struct_f
     Matrix_translate(arg1, arg2, 140.0f, MTXMODE_APPLY);
     Matrix_scale(arg3, arg3, 1.0f, MTXMODE_APPLY);
 
-    OPEN_DISPS(arg0);
-    OPEN_CUSTOM_POLY_OPA();
+    OPEN_POLY_OPA_DISP(arg0);
 
     gDPPipeSync(__polyOpa++);
     gSPMatrix(__polyOpa++, _Matrix_to_Mtx_new(arg0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -1186,8 +1160,7 @@ void mSM_draw_mail(GraphicsContext* arg0, f32 arg1, f32 arg2, f32 arg3, struct_f
     gDPSetAlphaCompare(__polyOpa++, G_AC_NONE);
     gDPSetBlendColor(__polyOpa++, 255, 255, 255, 8);
 
-    CLOSE_CUSTOM_POLY_OPA();
-    CLOSE_DISPS(arg0);
+    CLOSE_POLY_OPA_DISP(arg0);
 }
 
 void func_8085D094_jp(Submenu* submenu) {


### PR DESCRIPTION
These macros fix all of the old file-level CUSTOM_ZZZ macros. I also renamed unk_2B0 to 'font' as that's what it is in AC and seems to be used the same in Doubutsu no Mori.