### PR TITLE
Bootclear cleanup

### DIFF
--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -21,9 +21,9 @@ void bootclear(void) {
         bzero((void*)BOOT_ADDRESS_ULTRA, size);
     }
 
-    size = osMemSize - OS_K0_TO_PHYSICAL(SEGMENT_VRAM_START(dmadata));
+    size = osMemSize - OS_K0_TO_PHYSICAL(SEGMENT_VRAM_END(boot));
     if (size > 0) {
-        bzero(SEGMENT_VRAM_START(dmadata), size);
+        bzero(SEGMENT_VRAM_END(boot), size);
     }
 }
 

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -15,7 +15,7 @@ STACK(sBootStack, 0x400);
 
 // original name unknown
 void bootclear(void) {
-    s32 size = (uintptr_t)bootclear - BOOT_ADDRESS_ULTRA;
+    s32 size = (uintptr_t)SEGMENT_VRAM_START(boot) - BOOT_ADDRESS_ULTRA;
 
     if (size > 0) {
         bzero((void*)BOOT_ADDRESS_ULTRA, size);

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -60,7 +60,7 @@ void Idle_ThreadEntry(void* arg) {
     osViBlack(true);
     osCreatePiManager(OS_PRIORITY_PIMGR, &sPiMgrCmdQueue, sPiMgrCmdBuff, ARRAY_COUNT(sPiMgrCmdBuff));
     StackCheck_Init(&sMainStackInfo, sMainStack, STACK_TOP(sMainStack), 0, 0x400, "main");
-    osCreateThread(&sMainThread, M_THREAD_ID_MAIN, Main_ThreadEntry, arg, &sMainStackInfo, M_PRIORITY_MAIN);
+    osCreateThread(&sMainThread, M_THREAD_ID_MAIN, Main_ThreadEntry, arg, STACK_TOP(sMainStack), M_PRIORITY_MAIN);
     osStartThread(&sMainThread);
     osSetThreadPri(NULL, OS_PRIORITY_IDLE);
 


### PR DESCRIPTION
Mostly focused on a small cleanup in bootclear. Namely
1. `bootclear` is the start of the boot segment, so we can use `SEGMENT_VRAM_START(boot)` instead of the function directly
2. Seems better to use the end of the boot segment, rather then the start of the dmadata segment.

note: also fixes a small thread creation call that should have used the stack top instead of the stack info.