### PR TITLE
Extend usage of `mTM_TIME_TO_SEC` 

### DIFF
--- a/src/code/m_actor_shadow.c
+++ b/src/code/m_actor_shadow.c
@@ -4,6 +4,7 @@
 #include "macros.h"
 #include "sys_math3d.h"
 #include "m_field_info.h"
+#include "m_time.h"
 
 extern Gfx ef_shadow_out_modelT[];
 extern Gfx ef_shadow_in_modelT[];
@@ -50,19 +51,16 @@ void mActorShadow_GetTimeAngleY_TimeAlpha(ShadowInfo* shadow, Game_Play* play) {
     f32 angle;
     shadow->unk1C = play->kankyo.shadowAlpha;
 
-    // Between 4 a.m and 8 p.m
-    if ((timesec >= 14400) && (timesec < 72000)) {
+    if ((timesec >= mTM_TIME_TO_SEC(4, 0, 0)) && (timesec < mTM_TIME_TO_SEC(20, 0, 0))) {
         UNUSED f32 scopedTemp;
-        timef = (timesec - 14400) / 57600.0f;
+        timef = (timesec - mTM_TIME_TO_SEC(4, 0, 0)) / (f32)mTM_TIME_TO_SEC(16, 0, 0);
         angle = 16384;
-    } // Between 12 a.m and 4 a.m
-    else if (timesec < 14400) {
+    } else if (timesec < mTM_TIME_TO_SEC(4, 0, 0)) {
         UNUSED f32 scopedTemp;
-        timef = 0.5f + timesec / 28800.0f;
+        timef = 0.5f + timesec / (f32)mTM_TIME_TO_SEC(8, 0, 0);
         angle = 16384;
-    } // Between 8 p.m and 12 a.m
-    else {
-        timef = (timesec - 72000) / 28800.0f;
+    } else {
+        timef = (timesec - mTM_TIME_TO_SEC(20, 0, 0)) / (f32)mTM_TIME_TO_SEC(8, 0, 0);
         angle = 16384;
     }
 

--- a/src/overlays/actors/ovl_Lamp_Light/ef_lamp_light.c
+++ b/src/overlays/actors/ovl_Lamp_Light/ef_lamp_light.c
@@ -4,6 +4,7 @@
 #include "m_object.h"
 #include "m_field_info.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
+#include "m_time.h"
 
 #define THIS ((Lamp_Light*)thisx)
 
@@ -57,7 +58,7 @@ s32 eLL_get_light_sw_other_room(void) {
 
     temp_v0 = common_data.time.nowSec;
     var_v1 = 0;
-    if ((temp_v0 < 0x5460) || (temp_v0 >= 0xFD20)) {
+    if ((temp_v0 < mTM_TIME_TO_SEC(6, 0, 0)) || (temp_v0 >= mTM_TIME_TO_SEC(18, 0, 0))) {
         var_v1 = 1;
     }
     return var_v1;
@@ -68,7 +69,7 @@ s32 eLL_get_light_sw_player_room(Lamp_Light* this UNUSED) {
     s32 temp_v0;
 
     temp_v0 = common_data.time.nowSec;
-    var_v1 = ((temp_v0 >= 0xFD20) && (temp_v0 < 0x14370)) ? 1 : 0;
+    var_v1 = ((temp_v0 >= mTM_TIME_TO_SEC(18, 0, 0)) && (temp_v0 < mTM_TIME_TO_SEC(23, 0, 0))) ? 1 : 0;
     return var_v1;
 }
 

--- a/src/overlays/actors/ovl_Toudai/ac_toudai.c
+++ b/src/overlays/actors/ovl_Toudai/ac_toudai.c
@@ -7,6 +7,7 @@
 #include "m_collision_bg.h"
 #include "m_rcp.h"
 #include "m_lib.h"
+#include "m_time.h"
 #include "macros.h"
 #include "code_variables.h"
 
@@ -145,7 +146,8 @@ void aTOU_init(Toudai* this, Game_Play* game_play UNUSED) {
 }
 
 void aTOU_wait(Toudai* this, Game_Play* game_play UNUSED) {
-    if ((common_data.time.nowSec >= 0xFD20) || (common_data.time.nowSec < 0x4650)) {
+    if ((common_data.time.nowSec >= mTM_TIME_TO_SEC(18, 0, 0)) ||
+        (common_data.time.nowSec < mTM_TIME_TO_SEC(5, 0, 0))) {
         this->structureActor.unk_2BC = 1;
         this->structureActor.skeletonInfo.frameControl.speed = 1.0f;
         aTOU_setup_action(this, 2);
@@ -153,7 +155,8 @@ void aTOU_wait(Toudai* this, Game_Play* game_play UNUSED) {
 }
 
 void aTOU_lighting(Toudai* this, Game_Play* game_play UNUSED) {
-    if ((common_data.time.nowSec < 64800) && (common_data.time.nowSec >= 18000)) {
+    if ((common_data.time.nowSec < mTM_TIME_TO_SEC(18, 0, 0)) &&
+        (common_data.time.nowSec >= mTM_TIME_TO_SEC(5, 0, 0))) {
         aTOU_setup_action(this, 3);
     }
 }

--- a/src/overlays/actors/ovl_Train_Window/ac_train_window.c
+++ b/src/overlays/actors/ovl_Train_Window/ac_train_window.c
@@ -3,6 +3,7 @@
 #include "m_object.h"
 #include "evw_anime.h"
 #include "m_rcp.h"
+#include "m_time.h"
 #include "overlays/gamestates/ovl_play/m_play.h"
 
 void Train_Window_Actor_ct(Actor* thisx, Game_Play* game_play);
@@ -103,18 +104,22 @@ void Train_Window_Actor_dt(UNUSED Actor* thisx, UNUSED Game_Play* play) {
 }
 
 u8 aTW_GetNowAlpha(void) {
-    if ((common_data.time.nowSec >= 14400) && (common_data.time.nowSec < 72000)) {
-        if (common_data.time.nowSec < 43200) {
+    if ((common_data.time.nowSec >= mTM_TIME_TO_SEC(4, 0, 0)) &&
+        (common_data.time.nowSec < mTM_TIME_TO_SEC(20, 0, 0))) {
+        if (common_data.time.nowSec < mTM_TIME_TO_SEC(12, 0, 0)) {
             UNUSED f32 scopedTemp;
-            return ((void)0, 255.0f) * ((f32)(common_data.time.nowSec - 14400) / 28800.0f);
+            return ((void)0, 255.0f) *
+                   ((f32)(common_data.time.nowSec - mTM_TIME_TO_SEC(4, 0, 0)) / (f32)mTM_TIME_TO_SEC(8, 0, 0));
         } else {
-            return 255.0f * (1.0f - ((f32)(common_data.time.nowSec - 43200) / 28800.0f));
+            return 255.0f * (1.0f - ((f32)(common_data.time.nowSec - mTM_TIME_TO_SEC(12, 0, 0)) /
+                                     (f32)mTM_TIME_TO_SEC(8, 0, 0)));
         }
-    } else if (common_data.time.nowSec < 14400) {
+    } else if (common_data.time.nowSec < mTM_TIME_TO_SEC(4, 0, 0)) {
         UNUSED f32 scopedTemp;
-        return (1.0f - (0.5f + ((f32)common_data.time.nowSec / 28800.0f))) * 200.0f;
+        return (1.0f - (0.5f + ((f32)common_data.time.nowSec / (f32)mTM_TIME_TO_SEC(8, 0, 0)))) * 200.0f;
     } else {
-        return ((f32)(common_data.time.nowSec - 72000) / 28800.0f) * ((void)0, 200.0f);
+        return ((f32)(common_data.time.nowSec - mTM_TIME_TO_SEC(20, 0, 0)) / (f32)mTM_TIME_TO_SEC(8, 0, 0)) *
+               ((void)0, 200.0f);
     }
 }
 

--- a/src/overlays/gamestates/ovl_select/m_select.c
+++ b/src/overlays/gamestates/ovl_select/m_select.c
@@ -9,6 +9,7 @@
 #include "libc/alloca.h"
 #include "m_rcp.h"
 #include "audio.h"
+#include "m_time.h"
 
 #define nf_str(s0, s1) (s0 GFXPRINT_KATAKANA_MODE s1)
 NameFunction nf_tbl[SCENE_NUM] = {
@@ -83,7 +84,7 @@ void select_pass(Game_Select* select) {
     NameFunction* nfPtr;
     s32 scene = common_data.sceneFromTitleDemo;
 
-    common_data.time.nowSec = rtc->hour * 3600 + rtc->min * 60 + rtc->sec;
+    common_data.time.nowSec = mTM_TIME_TO_SEC(rtc->hour, rtc->min, rtc->sec);
     nfPtr = &nf_tbl[scene];
     if (nfPtr->nextProc != NULL) {
         (*nfPtr->nextProc)((Game*)select, nfPtr->sceneNo);
@@ -97,7 +98,7 @@ s32 select_start_proc(Game_Select* select) {
     s32 i;
 
     common_data.time.nowSec =
-        common_data.time.rtcTime.hour * 3600 + common_data.time.rtcTime.min * 60 + common_data.time.rtcTime.sec;
+        mTM_TIME_TO_SEC(common_data.time.rtcTime.hour, common_data.time.rtcTime.min, common_data.time.rtcTime.sec);
     nfPtr = &nf_tbl[select->selectedScene];
     if (nfPtr->nextProc != NULL) {
         (*nfPtr->nextProc)((Game*)select, nfPtr->sceneNo);


### PR DESCRIPTION
Saw that there was code where `nowSec` was used with total seconds, changed them to use `mTM_TIME_TO_SEC`  for better readability 