### PR TITLE
Fix mFI_Wpos2BlockNum calls

### DIFF
--- a/src/overlays/actors/ovl_Dump/ac_dump.c
+++ b/src/overlays/actors/ovl_Dump/ac_dump.c
@@ -146,14 +146,14 @@ void aDUM_actor_move(Actor* thisx, Game_Play* game_play) {
     Dump* this = THIS;
     Player* player = get_player_actor_withoutCheck(game_play);
     s32 xBlock;
-    s32 yBlock;
+    s32 zBlock;
     s32 playerXBlock;
-    s32 playerYBlock;
+    s32 playerZBlock;
 
-    mFI_Wpos2BlockNum(&xBlock, &yBlock, this->structureActor.actor.world.pos);
-    mFI_Wpos2BlockNum(&playerXBlock, &playerYBlock, player->actor.world.pos);
+    mFI_Wpos2BlockNum(&xBlock, &zBlock, this->structureActor.actor.world.pos);
+    mFI_Wpos2BlockNum(&playerXBlock, &playerZBlock, player->actor.world.pos);
     if ((mDemo_Check(1, &player->actor) == 0) && (mDemo_Check(5, &player->actor) == 0) &&
-        ((xBlock != playerXBlock) || (yBlock != playerYBlock))) {
+        ((xBlock != playerXBlock) || (zBlock != playerZBlock))) {
         Actor_delete(&this->structureActor.actor);
     } else {
         ((DumpActionFunc)this->structureActor.process)(this, game_play);

--- a/src/overlays/actors/ovl_Kago/ac_kago.c
+++ b/src/overlays/actors/ovl_Kago/ac_kago.c
@@ -90,14 +90,14 @@ void aKAG_actor_move(Actor* thisx, Game_Play* game_play) {
     Kago* this = THIS;
     Player* player = get_player_actor_withoutCheck(game_play);
     s32 xBlock;
-    s32 yBlock;
+    s32 zBlock;
     s32 playerXBlock;
-    s32 playerYBlock;
+    s32 playerZBlock;
 
-    mFI_Wpos2BlockNum(&xBlock, &yBlock, this->structureActor.actor.world.pos);
-    mFI_Wpos2BlockNum(&playerXBlock, &playerYBlock, player->actor.world.pos);
+    mFI_Wpos2BlockNum(&xBlock, &zBlock, this->structureActor.actor.world.pos);
+    mFI_Wpos2BlockNum(&playerXBlock, &playerZBlock, player->actor.world.pos);
     if ((mDemo_Check(1, &player->actor) == 0) && (mDemo_Check(5, &player->actor) == 0) &&
-        ((xBlock != playerXBlock) || (yBlock != playerYBlock))) {
+        ((xBlock != playerXBlock) || (zBlock != playerZBlock))) {
         Actor_delete(&this->structureActor.actor);
     } else {
         ((KagoActionFunc)this->structureActor.process)(this, game_play);

--- a/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
+++ b/src/overlays/actors/ovl_Koinobori/ac_koinobori.c
@@ -87,16 +87,16 @@ void aKOI_actor_move(Actor* thisx, Game_Play* game_play) {
     UNUSED s32 pad;
     Player* player = get_player_actor_withoutCheck(game_play);
     s32 blockX;
-    s32 blockY;
+    s32 blockZ;
     s32 playerBlockX;
-    s32 playerBlockY;
+    s32 playerBlockZ;
     UNUSED s32 pad2;
 
-    mFI_Wpos2BlockNum(&blockX, &blockY, this->structureActor.actor.world.pos);
-    mFI_Wpos2BlockNum(&playerBlockX, &playerBlockY, player->actor.world.pos);
+    mFI_Wpos2BlockNum(&blockX, &blockZ, this->structureActor.actor.world.pos);
+    mFI_Wpos2BlockNum(&playerBlockX, &playerBlockZ, player->actor.world.pos);
 
     if ((mDemo_Check(1, &player->actor) == 0) && (mDemo_Check(5, &player->actor) == 0) &&
-        ((blockX != playerBlockX) || (blockY != playerBlockY))) {
+        ((blockX != playerBlockX) || (blockZ != playerBlockZ))) {
         Actor_delete(&this->structureActor.actor);
         return;
     }

--- a/src/overlays/actors/ovl_Tama/ac_tama.c
+++ b/src/overlays/actors/ovl_Tama/ac_tama.c
@@ -76,14 +76,14 @@ void aTAM_actor_move(Actor* thisx, Game_Play* game_play) {
     Tama* this = THIS;
     Player* player = get_player_actor_withoutCheck(game_play);
     s32 xBlock;
-    s32 yBlock;
+    s32 zBlock;
     s32 playerXBlock;
-    s32 playerYBlock;
+    s32 playerZBlock;
 
-    mFI_Wpos2BlockNum(&xBlock, &yBlock, this->structureActor.actor.world.pos);
-    mFI_Wpos2BlockNum(&playerXBlock, &playerYBlock, player->actor.world.pos);
+    mFI_Wpos2BlockNum(&xBlock, &zBlock, this->structureActor.actor.world.pos);
+    mFI_Wpos2BlockNum(&playerXBlock, &playerZBlock, player->actor.world.pos);
     if ((mDemo_Check(1, &player->actor) == 0) && (mDemo_Check(5, &player->actor) == 0) &&
-        ((xBlock != playerXBlock) || (yBlock != playerYBlock))) {
+        ((xBlock != playerXBlock) || (zBlock != playerZBlock))) {
         Actor_delete(&this->structureActor.actor);
     } else {
         ((TamaActionFunc)this->structureActor.process)(this, game_play);


### PR DESCRIPTION
Thanks to Kuchen for pointing this out, the calls should pass x or z blocks, not y blocks